### PR TITLE
chrome: implement Chrome 90 compatible UUID generator based on the crypto API

### DIFF
--- a/sdk/src/evm/provider/eip6963.ts
+++ b/sdk/src/evm/provider/eip6963.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'utils/crypto';
 import { EIP6963AnnounceProviderEvent, EIP6963ProviderDetail, EIP6963ProviderInfo } from '../types';
 
 export const openfortProviderInfo = {
@@ -5,7 +6,7 @@ export const openfortProviderInfo = {
   icon: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="597.32 331.34 171.36 105.32" ><g><rect x="673.9" y="404.26" width="18.2" height="32.4" /><polygon points="768.68,331.36 768.68,331.36 768.68,331.34 610.78,331.34 610.78,331.36 597.32,331.36 597.32,436.64    615.52,436.64 615.52,349.54 750.48,349.54 750.48,436.64 768.68,436.64  " /><polygon points="732.16,367.79 633.83,367.79 633.83,370.19 633.79,370.19 633.79,436.64 651.99,436.64 651.99,385.99    713.9,385.99 713.9,436.64 732.09,436.64 732.09,385.99 732.16,385.99  " /></g></svg>',
   name: 'Openfort',
   rdns: 'xyz.openfort',
-  uuid: crypto.randomUUID(),
+  uuid: randomUUID()
 } as EIP6963ProviderInfo;
 
 export function announceProvider(

--- a/sdk/src/utils/crypto.ts
+++ b/sdk/src/utils/crypto.ts
@@ -3,6 +3,25 @@ import { bytesToHex as nobleBytesToHex, hexToBytes as nobleHexToBytes } from '@n
 
 export type Hex = `0x${string}`;
 
+// Pre-crypto API compatible UUID generator
+export function randomUUID() {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  // Per RFC4122 standard
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xxxxxx
+
+  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join('')
+  ].join('-');
+}
+
 export function bytesToHex(value: Uint8Array): Hex {
   const hex = nobleBytesToHex(value);
   return `0x${hex}`;


### PR DESCRIPTION
Unfortunately, Unreal Engine ships with (incredibly) outdated versions of Chrome - version 90. We noticed that multiple Unreal Engine users were having trouble setting up the signer due the the `crypto.randomUUID()` that was being called, which doesn't actually work until Chrome 92.

In order to mitigate that, here's a simple UUID generator based on the same crypto API but based on methods that were available in Chrome 90.