### PR TITLE
Change configure functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - 2025-08-29
+### Feat
+- Change API methods which configure method calls. Now it calls V2 methods
+- Dropped configuration attempts after "not configured" error from the iFrame
+
 ## [0.10.4] - 2025-08-29
 ### Feat
 - Export type ThirdPartyAuthConfiguration

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfort/openfort-js",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": "Openfort (https://www.openfort.io)",
   "bugs": "https://github.com/openfort-xyz/openfort-js/issues",
   "repository": "openfort-xyz/openfort-js.git",

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -25,7 +25,7 @@ import { EvmProvider, Provider } from '../wallets/evm';
 import { announceProvider, openfortProviderInfo } from '../wallets/evm/provider/eip6963';
 import { TypedDataPayload } from '../wallets/evm/types';
 import { signMessage } from '../wallets/evm/walletHelpers';
-import { IframeManager } from '../wallets/iframeManager';
+import { IframeManager, SignerConfigureRequest } from '../wallets/iframeManager';
 import { ReactNativeMessenger } from '../wallets/messaging';
 import { WindowMessenger } from '../wallets/messaging/browserMessenger';
 import { MessagePoster } from '../wallets/types';
@@ -226,11 +226,15 @@ export class EmbeddedWalletApi {
 
     const entropy = this.getEntropy(recoveryParams);
 
-    const signer = await this.ensureSigner();
-    const account = await signer.configure({
+    const configureParams: SignerConfigureRequest = {
       chainId: params.chainId,
       entropy,
-    });
+      accountType: params.accountType ?? AccountTypeEnum.SMART_ACCOUNT,
+      chainType: params.chainType ?? ChainTypeEnum.EVM,
+    };
+
+    const signer = await this.ensureSigner();
+    const account = await signer.configure(configureParams);
 
     const auth = await Authentication.fromStorage(this.storage);
     return {

--- a/sdk/src/types/types.ts
+++ b/sdk/src/types/types.ts
@@ -447,6 +447,8 @@ export type EmbeddedAccount = {
 export type EmbeddedAccountConfigureParams = {
   chainId?: number;
   recoveryParams: RecoveryParams;
+  chainType?: ChainTypeEnum;
+  accountType?: AccountTypeEnum;
 };
 
 export type EmbeddedAccountRecoverParams = {

--- a/sdk/src/version.ts
+++ b/sdk/src/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = '0.10.4';
+export const VERSION = '0.10.5';
 export const PACKAGE = '@openfort/openfort-js';

--- a/sdk/src/wallets/embedded.ts
+++ b/sdk/src/wallets/embedded.ts
@@ -58,9 +58,9 @@ export class EmbeddedSigner implements Signer {
       const response = await this.backendApiClients.accountsApi.getAccountsV2(
         {
           user: auth.player,
-          accountType: AccountTypeEnum.SMART_ACCOUNT,
+          accountType: params.accountType,
           // fine to hardcode here because configure is a legacy method from the time where there were only EVM accounts
-          chainType: ChainTypeEnum.EVM,
+          chainType: params.chainType,
         },
         {
           headers: {
@@ -77,8 +77,8 @@ export class EmbeddedSigner implements Signer {
 
       if (response.data.data.length === 0) {
         const createParams: SignerCreateRequest = {
-          accountType: AccountTypeEnum.SMART_ACCOUNT,
-          chainType: ChainTypeEnum.EVM,
+          accountType: params.accountType,
+          chainType: params.chainType,
           chainId: params.chainId,
           ...(params.entropy && {
             entropy: {

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -256,6 +256,7 @@ export class IframeManager {
   private handleError(error: any): never {
     if (isErrorResponse(error)) {
       if (error.error === NOT_CONFIGURED_ERROR) {
+        this.storage.remove(StorageKeys.ACCOUNT);
         throw new NotConfiguredError();
       } else if (error.error === MISSING_USER_ENTROPY_ERROR) {
         this.storage.remove(StorageKeys.ACCOUNT);
@@ -473,24 +474,16 @@ export class IframeManager {
     );
     debugLog('[iframe] done ensureConnection');
 
-    try {
-      const response = await remote.sign(request);
-      debugLog('[iframe] response', response);
-      if (isErrorResponse(response)) {
-        this.handleError(response);
-      }
-
-      if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('iframe-version', response.version ?? 'undefined');
-      }
-      return response.signature;
-    } catch (e) {
-      if (e instanceof NotConfiguredError) {
-        await this.configure();
-        return this.sign(message, requireArrayify, requireHash);
-      }
-      throw e;
+    const response = await remote.sign(request);
+    debugLog('[iframe] response', response);
+    if (isErrorResponse(response)) {
+      this.handleError(response);
     }
+
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('iframe-version', response.version ?? 'undefined');
+    }
+    return response.signature;
   }
 
   async switchChain(chainId: number): Promise<SwitchChainResponse> {
@@ -502,20 +495,12 @@ export class IframeManager {
       await this.buildRequestConfiguration(),
     );
 
-    try {
-      const response = await remote.switchChain(request);
+    const response = await remote.switchChain(request);
 
-      if (isErrorResponse(response)) {
-        this.handleError(response);
-      }
-      return response;
-    } catch (e) {
-      if (e instanceof NotConfiguredError) {
-        await this.configure();
-        return this.switchChain(chainId);
-      }
-      throw e;
+    if (isErrorResponse(response)) {
+      this.handleError(response);
     }
+    return response;
   }
 
   async export(): Promise<string> {
@@ -526,24 +511,16 @@ export class IframeManager {
       await this.buildRequestConfiguration(),
     );
 
-    try {
-      const response = await remote.export(request);
+    const response = await remote.export(request);
 
-      if (isErrorResponse(response)) {
-        this.handleError(response);
-      }
-
-      if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('iframe-version', (response as ExportPrivateKeyResponse).version ?? 'undefined');
-      }
-      return response.key;
-    } catch (e) {
-      if (e instanceof NotConfiguredError) {
-        await this.configure();
-        return this.export();
-      }
-      throw e;
+    if (isErrorResponse(response)) {
+      this.handleError(response);
     }
+
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('iframe-version', (response as ExportPrivateKeyResponse).version ?? 'undefined');
+    }
+    return response.key;
   }
 
   // eslint-disable-next-line consistent-return
@@ -562,22 +539,14 @@ export class IframeManager {
       await this.buildRequestConfiguration(),
     );
 
-    try {
-      const response = await remote.setRecoveryMethod(request);
+    const response = await remote.setRecoveryMethod(request);
 
-      if (isErrorResponse(response)) {
-        this.handleError(response);
-      }
+    if (isErrorResponse(response)) {
+      this.handleError(response);
+    }
 
-      if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('iframe-version', (response as SetRecoveryMethodResponse).version ?? 'undefined');
-      }
-    } catch (e) {
-      if (e instanceof NotConfiguredError) {
-        await this.configure();
-        return this.setRecoveryMethod(recoveryMethod, recoveryPassword, encryptionSession);
-      }
-      throw e;
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('iframe-version', (response as SetRecoveryMethodResponse).version ?? 'undefined');
     }
   }
 
@@ -618,19 +587,10 @@ export class IframeManager {
 
     const request = new UpdateAuthenticationRequest(randomUUID(), authentication.token);
 
-    try {
-      debugLog('Updating authentication in iframe with token:', authentication.token);
-      const response = await this.remote.updateAuthentication(request);
-      if (isErrorResponse(response)) {
-        this.handleError(response);
-      }
-    } catch (e) {
-      if (e instanceof NotConfiguredError) {
-        await this.configure();
-        await this.updateAuthentication();
-        return;
-      }
-      throw e;
+    debugLog('Updating authentication in iframe with token:', authentication.token);
+    const response = await this.remote.updateAuthentication(request);
+    if (isErrorResponse(response)) {
+      this.handleError(response);
     }
   }
 

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -64,7 +64,9 @@ export interface SignerConfigureRequest {
   entropy?: {
     recoveryPassword?: string;
     encryptionSession?: string;
-  }
+  };
+  accountType: AccountTypeEnum;
+  chainType: ChainTypeEnum;
 }
 
 export interface SignerCreateRequest {

--- a/sdk/src/wallets/types.ts
+++ b/sdk/src/wallets/types.ts
@@ -84,70 +84,6 @@ export class GetCurrentDeviceResponse implements IEventResponse {
   }
 }
 
-export class ConfigureRequest implements IEventRequest {
-  uuid: string;
-
-  action: Event = Event.CONFIGURE;
-
-  chainId: number | null;
-
-  recovery: ShieldAuthentication | null;
-
-  publishableKey: string;
-
-  shieldAPIKey: string;
-
-  accessToken: string | null;
-
-  encryptionKey: string | null;
-
-  encryptionPart: string | null;
-
-  encryptionSession: string | null;
-
-  openfortURL: string;
-
-  shieldURL: string;
-
-  thirdPartyProvider: string | null;
-
-  thirdPartyTokenType: string | null;
-
-  playerID: string | null;
-
-  constructor(
-    uuid: string,
-    chainId: number,
-    recovery: ShieldAuthentication,
-    publishableKey: string,
-    shieldAPIKey: string,
-    accessToken: string,
-    playerID: string,
-    openfortURL: string,
-    shieldURL: string,
-    encryptionKey = null,
-    thirdPartyProvider = null,
-    thirdPartyTokenType = null,
-    encryptionPart = null,
-    encryptionSession = null,
-  ) {
-    this.uuid = uuid;
-    this.chainId = chainId;
-    this.recovery = recovery;
-    this.publishableKey = publishableKey;
-    this.shieldAPIKey = shieldAPIKey;
-    this.accessToken = accessToken;
-    this.playerID = playerID;
-    this.thirdPartyProvider = thirdPartyProvider;
-    this.thirdPartyTokenType = thirdPartyTokenType;
-    this.encryptionKey = encryptionKey;
-    this.openfortURL = openfortURL;
-    this.shieldURL = shieldURL;
-    this.encryptionPart = encryptionPart;
-    this.encryptionSession = encryptionSession;
-  }
-}
-
 export class CreateRequest implements IEventRequest {
   uuid: string;
 
@@ -476,40 +412,6 @@ export class ErrorResponse implements IErrorResponse {
     this.success = false;
     this.error = error;
     this.uuid = uuid;
-    this.version = null;
-  }
-}
-
-export class ConfigureResponse implements IConfigureResponse {
-  uuid: string;
-
-  success: boolean;
-
-  account: string;
-
-  deviceID: string;
-
-  address: string;
-
-  chainId: number;
-
-  action: Event = Event.CONFIGURED;
-
-  version: string | null;
-
-  constructor(
-    uuid: string,
-    deviceID: string,
-    chainId: number,
-    address: string,
-    account: string,
-  ) {
-    this.success = true;
-    this.deviceID = deviceID;
-    this.uuid = uuid;
-    this.chainId = chainId;
-    this.address = address;
-    this.account = account;
     this.version = null;
   }
 }


### PR DESCRIPTION
# What
This PR changes API methods which configure method calls. Now it calls V2 methods.

Also in this PR were dropped retries after "not configured" error. Meaning now if we receive "not configured" error from the iFrame we clean the storage and ask user to recover the device again, instead of trying to handle it on our side(even though we cannot do it). So it's just remove of old, legacy code.

And `configure()` method at iFrameAPI interface was dropped as well because it's not used anymore.

# Note
This PR goes in pair with this one - https://github.com/openfort-xyz/iframe/pull/64