### PR TITLE
Extend request configuration struct with shield related data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.9] - 2025-09-05
+### Feat
+- Send more information for set recovery method on the iFrame
+
 ## [0.10.8] - 2025-09-03
 ### Feat
 - Wallet returns recovery method

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfort/openfort-js",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "author": "Openfort (https://www.openfort.io)",
   "bugs": "https://github.com/openfort-xyz/openfort-js/issues",
   "repository": "openfort-xyz/openfort-js.git",

--- a/sdk/src/version.ts
+++ b/sdk/src/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = '0.10.8';
+export const VERSION = '0.10.9';
 export const PACKAGE = '@openfort/openfort-js';

--- a/sdk/src/wallets/types.ts
+++ b/sdk/src/wallets/types.ts
@@ -297,14 +297,14 @@ export class SetRecoveryMethodRequest implements IEventRequest {
 
   encryptionSession?: string;
 
-  requestConfiguration?: RequestConfiguration;
+  requestConfiguration: RequestConfiguration;
 
   constructor(
     uuid: string,
     recoveryMethod: RecoveryMethod,
+    requestConfiguration: RequestConfiguration,
     recoveryPassword?: string,
     encryptionSession?: string,
-    requestConfiguration?: RequestConfiguration,
   ) {
     this.uuid = uuid;
     this.recoveryMethod = recoveryMethod;
@@ -586,12 +586,25 @@ export enum ShieldAuthType {
   OPENFORT = 'openfort',
 }
 
+// TODO: Most of these parameters are repeated in the iframe configuration.
+// Consider refactoring to avoid duplication.
+export interface IframeAuthentication extends ShieldAuthentication {
+  auth?: ShieldAuthType;
+  authProvider?: string | null;
+  token?: string | null;
+  tokenType?: string | null;
+}
+
 export interface RequestConfiguration {
   token?: string;
   thirdPartyProvider?: string;
   thirdPartyTokenType?: string;
   publishableKey: string;
   openfortURL?: string;
+  shieldAuthentication: IframeAuthentication;
+  shieldAPIKey: string;
+  shieldURL: string;
+  encryptionKey?: string;
 }
 
 export interface MessagePoster {


### PR DESCRIPTION
# What
This PR changes `RequestConfiguration` struct a little bit. Here we add shield related data so iFrame could process requests without additional info from it's state.