### PR TITLE
fix(embedded-wallet): set iframe referrer policy

### DIFF
--- a/.changeset/iframe-referrer-policy.md
+++ b/.changeset/iframe-referrer-policy.md
@@ -1,0 +1,9 @@
+---
+"@openfort/openfort-js": patch
+---
+
+Set `referrerpolicy="strict-origin-when-cross-origin"` on the embedded wallet
+iframe so the parent origin is sent on the iframe document request. Without
+this, parent pages with a restrictive `Referrer-Policy` (e.g. `no-referrer`,
+`same-origin`) caused the server-side allowlist check at
+`/v1/projects/validate-origin` to receive an empty origin and return 403.

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -233,6 +233,11 @@ export class EmbeddedWalletApi {
     const iframe = document.createElement('iframe')
     iframe.style.display = 'none'
     iframe.id = 'openfort-iframe'
+    // Ensure the parent origin is sent on the iframe document request so the
+    // server-side origin allowlist can be evaluated, even when the parent page
+    // sets a restrictive Referrer-Policy (e.g. `no-referrer`, `same-origin`).
+    // Without this, the browser strips Referer and validate-origin returns 403.
+    iframe.referrerPolicy = 'strict-origin-when-cross-origin'
     iframe.src = url
 
     document.body.appendChild(iframe)


### PR DESCRIPTION
## Summary
- Set `iframe.referrerPolicy = 'strict-origin-when-cross-origin'` in `createIframe` so the parent origin is sent on the iframe document request.
- Without this, parent pages with a restrictive `Referrer-Policy` (e.g. `no-referrer`, `same-origin`) caused `embed.openfort.io/iframe/<pk>` to load with no `Referer` and no `Origin`. The server-side allowlist check at `/v1/projects/validate-origin` then defaults to a literal `"openfort.io"` and returns 403 for any project whose dashboard has a configured allowlist.

## Why
Cloudflare 7d data (host `embed.openfort.io`):
- 19 × 403 across 3 customer pks in the past week, geographically clustered (ES/RS).
- For one affected pk: 200 every time `Referer` is `https://<customer>.com/`; 403 every time `Referer` is missing.
- A different pk with no allowlist configured (`allowedOrigins = []`) returns 200 with an empty `Referer`, confirming the failure mode is the allowlist evaluation, not a Referer-presence gate.

The pattern correlates with Google OAuth flows because the OAuth redirect chain (Google → customer callback) commonly strips referrer.

## Behaviour after this change
The `referrerpolicy` attribute on an iframe element overrides the parent document's `Referrer-Policy` for that specific subresource load. With `strict-origin-when-cross-origin`, the browser sends the parent origin (not the full URL) on cross-origin loads, regardless of the parent's policy.

## What this does *not* fix
- The server still silently returns a 26-byte HTML body on deny, with no diagnostic header or structured log. A follow-up will add an `X-Reject-Reason` response header and a `WARN` log on the api side so future regressions are debuggable.
- Customer documentation about referrer policies and the embedded wallet — separate doc PR.

## Test plan
- [ ] Manual: load embedded wallet from a parent that sets `<meta name="referrer" content="no-referrer">`. Confirm iframe loads (was 403 before).
- [ ] Manual: load from a parent with `Referrer-Policy: strict-origin-when-cross-origin` (default). Confirm no regression.
- [ ] Verify build / type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)