### PR TITLE
Reject malformed typed data chain IDs

### DIFF
--- a/sdk/src/wallets/evm/signTypedDataV4.test.ts
+++ b/sdk/src/wallets/evm/signTypedDataV4.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { JsonRpcError } from './JsonRpcError'
+import { parseTypedDataChainId } from './signTypedDataV4'
+
+describe('parseTypedDataChainId', () => {
+  it('parses decimal and hex string chain IDs', () => {
+    expect(parseTypedDataChainId('8453')).toBe(8453)
+    expect(parseTypedDataChainId('0x2105')).toBe(8453)
+  })
+
+  it('rejects malformed chain IDs', () => {
+    expect(() => parseTypedDataChainId('8453abc')).toThrow(JsonRpcError)
+    expect(() => parseTypedDataChainId('0x2105xyz')).toThrow(JsonRpcError)
+  })
+})

--- a/sdk/src/wallets/evm/signTypedDataV4.ts
+++ b/sdk/src/wallets/evm/signTypedDataV4.ts
@@ -18,6 +18,24 @@ const REQUIRED_TYPED_DATA_PROPERTIES = ['types', 'domain', 'primaryType', 'messa
 const isValidTypedDataPayload = (typedData: object): typedData is TypedDataPayload =>
   REQUIRED_TYPED_DATA_PROPERTIES.every((key) => key in typedData)
 
+export const parseTypedDataChainId = (chainId: string | number): number => {
+  if (typeof chainId === 'number') {
+    return chainId
+  }
+
+  const isHex = chainId.startsWith('0x')
+  if (isHex ? !/^0x[0-9a-fA-F]+$/.test(chainId) : !/^\d+$/.test(chainId)) {
+    throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, `Invalid chainId: ${chainId}`)
+  }
+
+  const parsed = Number.parseInt(chainId, isHex ? 16 : 10)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, `Invalid chainId: ${chainId}`)
+  }
+
+  return parsed
+}
+
 const transformTypedData = (typedData: string | object, chainId: number): TypedDataPayload => {
   let transformedTypedData: object | TypedDataPayload
 
@@ -44,13 +62,7 @@ const transformTypedData = (typedData: string | object, chainId: number): TypedD
   const providedChainId: number | string | undefined = (transformedTypedData as any).domain?.chainId
   if (providedChainId) {
     // domain.chainId (if defined) can be a number, string, or hex value, but the backend & guardian only accept a number.
-    if (typeof providedChainId === 'string') {
-      if (providedChainId.startsWith('0x')) {
-        transformedTypedData.domain.chainId = parseInt(providedChainId, 16)
-      } else {
-        transformedTypedData.domain.chainId = parseInt(providedChainId, 10)
-      }
-    }
+    transformedTypedData.domain.chainId = parseTypedDataChainId(providedChainId)
 
     if (transformedTypedData.domain.chainId !== chainId) {
       throw new JsonRpcError(RpcErrorCode.INVALID_PARAMS, `Invalid chainId, expected ${chainId}`)


### PR DESCRIPTION
## Summary

Reject malformed EIP-712 `domain.chainId` strings before comparing them with the active network chain ID.

## Why

`eth_signTypedData_v4` accepts `domain.chainId` as a number, decimal string, or hex string. The current conversion uses `parseInt`, which accepts partial strings like `8453abc` or `0x2105xyz` and turns them into `8453`.

That allows malformed typed data to pass chain ID validation as long as the numeric prefix matches the active chain.

## Change

- Adds a small parser that requires decimal strings to be digits-only and hex strings to be valid `0x...` hex.
- Keeps support for numeric, decimal-string, and hex-string chain IDs.
- Adds regression coverage for malformed chain ID strings.
