### PR TITLE
docs(funding): note /v2/funding is now in the OpenAPI spec

### DIFF
--- a/sdk/src/api/funding.ts
+++ b/sdk/src/api/funding.ts
@@ -9,9 +9,12 @@ import { ConfigurationError, RequestError } from '../core/errors/openfortError'
  * deposit address, then poll until terminal. Sessions are guarded by a
  * per-session `clientSecret` and authenticated with the project publishable key.
  *
- * NOTE: This thin wrapper calls the backend directly. Once the API's funding
- * endpoints are part of the published OpenAPI spec, this can move onto the
- * generated `BackendApiClients.fundingApi` like the other resources.
+ * NOTE: This thin wrapper calls the backend directly. The API's `/v2/funding`
+ * endpoints are now in the published OpenAPI spec (tag `Funding`: createFundingSession,
+ * SetPaymentMethod, getFundingSession, CreatePayLink, ListChains), so regenerating
+ * `@openfort/openapi-clients` (`make generate-backend-openapi`) produces a `FundingApi`
+ * and this wrapper can then delegate to `BackendApiClients.fundingApi` like the other
+ * resources — keeping the clientSecret memory + ergonomics in this class.
  */
 
 /** Where the funded crypto should land (CAIP-2 chain + token + wallet). */


### PR DESCRIPTION
## What

Corrects the `FundingApi` doc comment: the `/v2/funding` endpoints are **now in the published OpenAPI spec** (verified against `api.openfort.io/api-docs/swagger.json` — tag `Funding`; operationIds `createFundingSession`, `SetPaymentMethod`, `getFundingSession`, `CreatePayLink`, `ListChains`; `fundingSession` schema). The old comment said they *weren't* yet.

## Why / follow-up

`packages/internal/openapi-clients` is generated from that spec but is stale — it predates funding, so `BackendApiClients` has no `FundingApi` and `sdk/src/api/funding.ts` hand-rolls the calls. Regenerating the client (`make generate-backend-openapi`) will produce a `FundingApi`, after which this wrapper can delegate to `BackendApiClients.fundingApi` while keeping the clientSecret memory + ergonomics. This PR just makes the comment accurate and points at that path; the regen + delegation is a follow-up (it needs the Docker/Java generator toolchain).

Comment-only change. Funding unit tests pass (7/7); biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)