### PR TITLE
fix: improve iframe connection reliability

### DIFF
--- a/.changeset/iframe-connection-reliability.md
+++ b/.changeset/iframe-connection-reliability.md
@@ -1,0 +1,5 @@
+---
+"@openfort/openfort-js": patch
+---
+
+Harden iframe connection reliability: per-call RPC timeouts with typed errors (`IframeRpcTimeoutError`, `IframeConnectionDestroyedError`), a transparent one-shot handshake retry, and a new `onEmbeddedWalletConnectionLost` event with per-reason semantics (`rpc-timeout`, `handshake-timeout`, `iframe-reloaded`). Teardown no longer sends a penpal DESTROY to React Native WebView children (which permanently deafened them), the EIP-1193 provider rebuilds its signer after a connection loss instead of failing until logout, logout is bounded against a frozen iframe and flushes embed-side state even after a page reload, and mid-session embed reloads are reported exactly once (no false positives from the deprecated wire protocol's duplicate ACKs).

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,17 +6,13 @@ on:
   merge_group:
     branches:
       - main
-# A new push supersedes any in-flight run for the same ref — without this,
-# rapid pushes stack full runs that all burn runners to completion.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  # Main suite: the KNOWN shared E2E account with pre-provisioned wallet
-  # state, exactly as it always ran — serial (workers: 1, since tests share
-  # that account) across chromium/firefox/webkit. The connection-reliability
-  # stress spec is the only exclusion; it runs in the parallel guest-based
-  # job below instead of extending this one.
+  # Main suite: serial (tests share one E2E account) across
+  # chromium/firefox/webkit. The connection-reliability spec is guest-based
+  # and runs in the parallel `reliability` job below instead.
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -45,8 +41,6 @@ jobs:
     - name: Build SDK
       run: pnpm build
 
-    # Next.js incremental build cache — cuts the production build of the
-    # sample app on warm runs.
     - name: Cache Next.js build
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -68,8 +62,6 @@ jobs:
       run: pnpm build
       working-directory: examples/apps/auth-sample
 
-    # Browser binaries change only when the Playwright version does — cache
-    # them instead of re-downloading every run.
     - name: Cache Playwright browsers
       id: playwright-cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -102,8 +94,6 @@ jobs:
         NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
         NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
         E2E_TESTS_USER: ${{ vars.E2E_TESTS_USER }}
-      # Everything except the reliability project (guest-based, runs in the
-      # parallel job below) — i.e. the suite exactly as it ran before.
       run: pnpm playwright test --project=setup --project=chromium --project=firefox --project=webkit --reporter=dot
       working-directory: examples/apps/auth-sample
 
@@ -111,19 +101,17 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: playwright-report
-        # test-results/ holds the retry traces and error contexts — the dot
-        # reporter never writes playwright-report/, so without this the
-        # artifact was always empty and failures shipped no evidence.
+        # The dot reporter doesn't write playwright-report/; failure evidence
+        # (retry traces, error contexts) lands in test-results/.
         path: |
           examples/apps/auth-sample/playwright-report/
           examples/apps/auth-sample/test-results/
         retention-days: 30
         if-no-files-found: ignore
 
-  # Connection-reliability stress suite. Guest-account based (a fresh guest
-  # per test), so it never touches the shared E2E account — it runs here in
-  # parallel with the main job and with parallel workers, instead of adding
-  # ~10 serial minutes to it. Chromium only by design.
+  # Connection-reliability stress suite. A fresh guest account per test, so
+  # it never touches the shared E2E account and can run in parallel with the
+  # main job. Chromium only by design.
   reliability:
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -173,7 +161,6 @@ jobs:
       run: pnpm build
       working-directory: examples/apps/auth-sample
 
-    # This job only needs chromium.
     - name: Cache Playwright browsers (chromium)
       id: playwright-cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,12 +12,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  # Main suite. Serial (workers: 1) because every test shares ONE E2E account
-  # — logout/recovery-method changes in one test corrupt another's session.
-  # PRs run chromium only for fast feedback; the merge queue runs the full
-  # browser matrix before anything lands on main.
+  # Main suite: the KNOWN shared E2E account with pre-provisioned wallet
+  # state, exactly as it always ran — serial (workers: 1, since tests share
+  # that account) across chromium/firefox/webkit. The connection-reliability
+  # stress spec is the only exclusion; it runs in the parallel guest-based
+  # job below instead of extending this one.
   test:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,8 +87,7 @@ jobs:
       run: pnpm playwright install-deps
       working-directory: examples/apps/auth-sample
 
-    - name: Run Playwright tests (chromium — pull request)
-      if: github.event_name == 'pull_request'
+    - name: Run Playwright tests
       env:
         NEXTAUTH_OPENFORT_SECRET_KEY: ${{ secrets.NEXTAUTH_OPENFORT_SECRET_KEY }}
         NEXTAUTH_SHIELD_ENCRYPTION_KEY: ${{ secrets.NEXTAUTH_SHIELD_ENCRYPTION_KEY }}
@@ -102,25 +102,8 @@ jobs:
         NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
         NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
         E2E_TESTS_USER: ${{ vars.E2E_TESTS_USER }}
-      run: pnpm playwright test --project=setup --project=chromium --reporter=dot
-      working-directory: examples/apps/auth-sample
-
-    - name: Run Playwright tests (all browsers — merge queue)
-      if: github.event_name == 'merge_group'
-      env:
-        NEXTAUTH_OPENFORT_SECRET_KEY: ${{ secrets.NEXTAUTH_OPENFORT_SECRET_KEY }}
-        NEXTAUTH_SHIELD_ENCRYPTION_KEY: ${{ secrets.NEXTAUTH_SHIELD_ENCRYPTION_KEY }}
-        NEXTAUTH_SHIELD_SECRET_KEY: ${{ secrets.NEXTAUTH_SHIELD_SECRET_KEY }}
-        E2E_TESTS_PASSWORD: ${{ secrets.E2E_TESTS_PASSWORD }}
-        NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY }}
-        NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY }}
-        NEXT_PUBLIC_POLICY_ID: ${{ vars.NEXT_PUBLIC_POLICY_ID }}
-        NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
-        NEXT_PUBLIC_CONTRACT_ID: ${{ vars.NEXT_PUBLIC_CONTRACT_ID }}
-        NEXT_PUBLIC_REOWN_PROJECT_ID: ${{ vars.NEXT_PUBLIC_REOWN_PROJECT_ID }}
-        NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
-        NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
-        E2E_TESTS_USER: ${{ vars.E2E_TESTS_USER }}
+      # Everything except the reliability project (guest-based, runs in the
+      # parallel job below) — i.e. the suite exactly as it ran before.
       run: pnpm playwright test --project=setup --project=chromium --project=firefox --project=webkit --reporter=dot
       working-directory: examples/apps/auth-sample
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,11 @@ on:
   merge_group:
     branches:
       - main
+# A new push supersedes any in-flight run for the same ref — without this,
+# rapid pushes stack full ~40-minute runs that all burn runners to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     timeout-minutes: 60
@@ -35,6 +40,16 @@ jobs:
     - name: Build SDK
       run: pnpm build
 
+    # Next.js incremental build cache — cuts the production build of the
+    # sample app on warm runs.
+    - name: Cache Next.js build
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: examples/apps/auth-sample/.next/cache
+        key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('examples/apps/auth-sample/src/**', 'sdk/src/**') }}
+        restore-keys: |
+          nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
     - name: Build auth-sample for production
       env:
         NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY }}
@@ -48,8 +63,24 @@ jobs:
       run: pnpm build
       working-directory: examples/apps/auth-sample
 
+    # Browser binaries are ~500MB across chromium/firefox/webkit and change
+    # only when the Playwright version does — cache them instead of
+    # re-downloading every run (~2-4 minutes).
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
     - name: Install Playwright Browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: pnpm playwright install --with-deps
+      working-directory: examples/apps/auth-sample
+
+    - name: Install Playwright system dependencies (cached browsers)
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm playwright install-deps
       working-directory: examples/apps/auth-sample
 
     - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,13 +7,17 @@ on:
     branches:
       - main
 # A new push supersedes any in-flight run for the same ref — without this,
-# rapid pushes stack full ~40-minute runs that all burn runners to completion.
+# rapid pushes stack full runs that all burn runners to completion.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  # Main suite. Serial (workers: 1) because every test shares ONE E2E account
+  # — logout/recovery-method changes in one test corrupt another's session.
+  # PRs run chromium only for fast feedback; the merge queue runs the full
+  # browser matrix before anything lands on main.
   test:
-    timeout-minutes: 60
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,9 +67,8 @@ jobs:
       run: pnpm build
       working-directory: examples/apps/auth-sample
 
-    # Browser binaries are ~500MB across chromium/firefox/webkit and change
-    # only when the Playwright version does — cache them instead of
-    # re-downloading every run (~2-4 minutes).
+    # Browser binaries change only when the Playwright version does — cache
+    # them instead of re-downloading every run.
     - name: Cache Playwright browsers
       id: playwright-cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -83,7 +86,8 @@ jobs:
       run: pnpm playwright install-deps
       working-directory: examples/apps/auth-sample
 
-    - name: Run Playwright tests
+    - name: Run Playwright tests (chromium — pull request)
+      if: github.event_name == 'pull_request'
       env:
         NEXTAUTH_OPENFORT_SECRET_KEY: ${{ secrets.NEXTAUTH_OPENFORT_SECRET_KEY }}
         NEXTAUTH_SHIELD_ENCRYPTION_KEY: ${{ secrets.NEXTAUTH_SHIELD_ENCRYPTION_KEY }}
@@ -98,12 +102,125 @@ jobs:
         NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
         NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
         E2E_TESTS_USER: ${{ vars.E2E_TESTS_USER }}
-      run: pnpm playwright test --reporter=dot
+      run: pnpm playwright test --project=setup --project=chromium --reporter=dot
+      working-directory: examples/apps/auth-sample
+
+    - name: Run Playwright tests (all browsers — merge queue)
+      if: github.event_name == 'merge_group'
+      env:
+        NEXTAUTH_OPENFORT_SECRET_KEY: ${{ secrets.NEXTAUTH_OPENFORT_SECRET_KEY }}
+        NEXTAUTH_SHIELD_ENCRYPTION_KEY: ${{ secrets.NEXTAUTH_SHIELD_ENCRYPTION_KEY }}
+        NEXTAUTH_SHIELD_SECRET_KEY: ${{ secrets.NEXTAUTH_SHIELD_SECRET_KEY }}
+        E2E_TESTS_PASSWORD: ${{ secrets.E2E_TESTS_PASSWORD }}
+        NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_POLICY_ID: ${{ vars.NEXT_PUBLIC_POLICY_ID }}
+        NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
+        NEXT_PUBLIC_CONTRACT_ID: ${{ vars.NEXT_PUBLIC_CONTRACT_ID }}
+        NEXT_PUBLIC_REOWN_PROJECT_ID: ${{ vars.NEXT_PUBLIC_REOWN_PROJECT_ID }}
+        NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
+        NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
+        E2E_TESTS_USER: ${{ vars.E2E_TESTS_USER }}
+      run: pnpm playwright test --project=setup --project=chromium --project=firefox --project=webkit --reporter=dot
       working-directory: examples/apps/auth-sample
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ !cancelled() }}
       with:
         name: playwright-report
+        path: examples/apps/auth-sample/playwright-report/
+        retention-days: 30
+
+  # Connection-reliability stress suite. Guest-account based (a fresh guest
+  # per test), so it never touches the shared E2E account — it runs here in
+  # parallel with the main job and with parallel workers, instead of adding
+  # ~10 serial minutes to it. Chromium only by design.
+  reliability:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      with:
+        version: 10.16.1
+
+    - name: Setup Node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 24
+        cache: 'pnpm'
+
+    - name: Install root dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Build SDK
+      run: pnpm build
+
+    - name: Cache Next.js build
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: examples/apps/auth-sample/.next/cache
+        key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('examples/apps/auth-sample/src/**', 'sdk/src/**') }}
+        restore-keys: |
+          nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
+    - name: Build auth-sample for production
+      env:
+        NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_POLICY_ID: ${{ vars.NEXT_PUBLIC_POLICY_ID }}
+        NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
+        NEXT_PUBLIC_CONTRACT_ID: ${{ vars.NEXT_PUBLIC_CONTRACT_ID }}
+        NEXT_PUBLIC_REOWN_PROJECT_ID: ${{ vars.NEXT_PUBLIC_REOWN_PROJECT_ID }}
+        NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
+        NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
+      run: pnpm build
+      working-directory: examples/apps/auth-sample
+
+    # This job only needs chromium.
+    - name: Cache Playwright browsers (chromium)
+      id: playwright-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Install Playwright chromium
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: pnpm playwright install --with-deps chromium
+      working-directory: examples/apps/auth-sample
+
+    - name: Install Playwright system dependencies (cached browser)
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm playwright install-deps chromium
+      working-directory: examples/apps/auth-sample
+
+    - name: Run connection-reliability stress tests
+      env:
+        NEXTAUTH_OPENFORT_SECRET_KEY: ${{ secrets.NEXTAUTH_OPENFORT_SECRET_KEY }}
+        NEXTAUTH_SHIELD_ENCRYPTION_KEY: ${{ secrets.NEXTAUTH_SHIELD_ENCRYPTION_KEY }}
+        NEXTAUTH_SHIELD_SECRET_KEY: ${{ secrets.NEXTAUTH_SHIELD_SECRET_KEY }}
+        NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_OPENFORT_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SHIELD_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_POLICY_ID: ${{ vars.NEXT_PUBLIC_POLICY_ID }}
+        NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
+        NEXT_PUBLIC_CONTRACT_ID: ${{ vars.NEXT_PUBLIC_CONTRACT_ID }}
+        NEXT_PUBLIC_REOWN_PROJECT_ID: ${{ vars.NEXT_PUBLIC_REOWN_PROJECT_ID }}
+        NEXT_PUBLIC_COINBASE_PROJECTID: ${{ vars.NEXT_PUBLIC_COINBASE_PROJECTID }}
+        NEXT_PUBLIC_MOONPAY_API_KEY: ${{ vars.NEXT_PUBLIC_MOONPAY_API_KEY }}
+      run: pnpm playwright test --project=reliability --workers=3 --reporter=dot
+      working-directory: examples/apps/auth-sample
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report-reliability
         path: examples/apps/auth-sample/playwright-report/
         retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -111,8 +111,14 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: playwright-report
-        path: examples/apps/auth-sample/playwright-report/
+        # test-results/ holds the retry traces and error contexts — the dot
+        # reporter never writes playwright-report/, so without this the
+        # artifact was always empty and failures shipped no evidence.
+        path: |
+          examples/apps/auth-sample/playwright-report/
+          examples/apps/auth-sample/test-results/
         retention-days: 30
+        if-no-files-found: ignore
 
   # Connection-reliability stress suite. Guest-account based (a fresh guest
   # per test), so it never touches the shared E2E account — it runs here in
@@ -205,5 +211,8 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: playwright-report-reliability
-        path: examples/apps/auth-sample/playwright-report/
+        path: |
+          examples/apps/auth-sample/playwright-report/
+          examples/apps/auth-sample/test-results/
         retention-days: 30
+        if-no-files-found: ignore

--- a/examples/apps/auth-sample/next.config.js
+++ b/examples/apps/auth-sample/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Playwright drives the app via http://127.0.0.1:3000 while `next dev`
+  // binds to localhost — allow the alternate host for dev resources (HMR).
+  allowedDevOrigins: ['127.0.0.1'],
   transpilePackages: ['@rainbow-me/rainbowkit'],
   serverExternalPackages: ['pino', 'pino-pretty', 'thread-stream', 'lokijs', 'encoding'],
   turbopack: {

--- a/examples/apps/auth-sample/playwright.config.ts
+++ b/examples/apps/auth-sample/playwright.config.ts
@@ -54,6 +54,20 @@ export default defineConfig({
         storageState: 'playwright/.auth/user.json',
       },
       dependencies: ['setup'],
+      // The connection-reliability stress suite runs in its own project (and
+      // its own CI job): it uses fresh guest accounts, so unlike the rest of
+      // the suite it doesn't touch the shared E2E account and can run in
+      // parallel instead of extending this serial run.
+      testIgnore: ['**/connectionReliability.spec.ts'],
+    },
+
+    {
+      // Connection-reliability stress tests. Guest-account based: no setup
+      // dependency, no shared auth state, safe to run with parallel workers
+      // and concurrently with the main suite.
+      name: 'reliability',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: ['**/connectionReliability.spec.ts'],
     },
 
     {

--- a/examples/apps/auth-sample/src/utils/openfortConfig.ts
+++ b/examples/apps/auth-sample/src/utils/openfortConfig.ts
@@ -24,4 +24,19 @@ const openfort = new Openfort({
   },
 })
 
+// E2E/debug hooks: expose the SDK instance and record connection-health
+// events so stress tests can assert exactly-once event semantics
+// (tests/connectionReliability.spec.ts). No-op during SSR.
+if (typeof window !== 'undefined') {
+  const w = window as unknown as {
+    __openfort?: unknown
+    __connectionLostEvents?: unknown[]
+  }
+  w.__openfort = openfort
+  w.__connectionLostEvents = []
+  Openfort.getEventEmitter().on('onEmbeddedWalletConnectionLost', (payload: unknown) => {
+    w.__connectionLostEvents?.push(payload)
+  })
+}
+
 export default openfort

--- a/examples/apps/auth-sample/tests/authenticate.ts
+++ b/examples/apps/auth-sample/tests/authenticate.ts
@@ -76,9 +76,8 @@ export async function authenticateAndRecover(page: Page) {
   switch (recoveryMethod) {
     case RecoveryMethod.AUTOMATIC: {
       await expect(page.locator('div.spinner')).toBeInViewport()
-      // Recovery RPCs are bounded at 120s inside the SDK — if the spinner is
-      // still up past 150s the flow is genuinely hung; fail fast instead of
-      // burning the whole test timeout (and its retries) on a known-bad state.
+      // The SDK bounds recovery RPCs at 120s — past 150s the flow is hung, so
+      // fail fast instead of burning the whole test timeout.
       await page.locator('div.spinner').waitFor({ state: 'hidden', timeout: 150_000 })
       await page.waitForTimeout(500)
       const consoleExists = (await page.getByRole('heading', { name: 'Console' }).count()) > 0
@@ -93,9 +92,7 @@ export async function authenticateAndRecover(page: Page) {
       await page.getByRole('button', { name: 'Use this wallet' }).click()
 
       await expect(page.locator('div.spinner')).toBeInViewport()
-      // Recovery RPCs are bounded at 120s inside the SDK — if the spinner is
-      // still up past 150s the flow is genuinely hung; fail fast instead of
-      // burning the whole test timeout (and its retries) on a known-bad state.
+      // Same 150s bound as the automatic-recovery path above.
       await page.locator('div.spinner').waitFor({ state: 'hidden', timeout: 150_000 })
 
       await expect(page.getByRole('heading', { name: 'Console' }), {

--- a/examples/apps/auth-sample/tests/authenticate.ts
+++ b/examples/apps/auth-sample/tests/authenticate.ts
@@ -76,7 +76,10 @@ export async function authenticateAndRecover(page: Page) {
   switch (recoveryMethod) {
     case RecoveryMethod.AUTOMATIC: {
       await expect(page.locator('div.spinner')).toBeInViewport()
-      await page.locator('div.spinner').waitFor({ state: 'hidden' })
+      // Recovery RPCs are bounded at 120s inside the SDK — if the spinner is
+      // still up past 150s the flow is genuinely hung; fail fast instead of
+      // burning the whole test timeout (and its retries) on a known-bad state.
+      await page.locator('div.spinner').waitFor({ state: 'hidden', timeout: 150_000 })
       await page.waitForTimeout(500)
       const consoleExists = (await page.getByRole('heading', { name: 'Console' }).count()) > 0
       expect(consoleExists).toBe(true)
@@ -90,7 +93,10 @@ export async function authenticateAndRecover(page: Page) {
       await page.getByRole('button', { name: 'Use this wallet' }).click()
 
       await expect(page.locator('div.spinner')).toBeInViewport()
-      await page.locator('div.spinner').waitFor({ state: 'hidden' })
+      // Recovery RPCs are bounded at 120s inside the SDK — if the spinner is
+      // still up past 150s the flow is genuinely hung; fail fast instead of
+      // burning the whole test timeout (and its retries) on a known-bad state.
+      await page.locator('div.spinner').waitFor({ state: 'hidden', timeout: 150_000 })
 
       await expect(page.getByRole('heading', { name: 'Console' }), {
         // error message in case it fails:

--- a/examples/apps/auth-sample/tests/connectionReliability.spec.ts
+++ b/examples/apps/auth-sample/tests/connectionReliability.spec.ts
@@ -1,0 +1,180 @@
+import test, { expect, type Page } from '@playwright/test'
+import { authenticate, authenticateAndRecover } from './authenticate'
+import { Logger } from './Logger'
+
+/**
+ * Non-happy-path stress tests for the iframe connection-reliability work
+ * (branch fix/iframe-connection-reliability, SDK + embed):
+ *
+ * - handshake timeout → transparent one-shot retry (no spurious events)
+ * - unreachable embed → typed failure, exactly ONE connection-lost event,
+ *   and full recovery once the embed is reachable again
+ * - embed page reloaded mid-session → exactly one 'iframe-reloaded' event
+ *   (the deprecated-protocol duplicate-ACK path must stay silent)
+ * - logout against a dead embed → bounded, and NEVER reported as a
+ *   connection loss (intentional teardown)
+ * - logout right after a page reload → best-effort iframe flush + cleanup
+ * - repeated login/logout cycles → connection rebuild leaks nothing
+ *
+ * These tests run against the LOCAL embed dev server (NEXT_PUBLIC_IFRAME_URL),
+ * intercepting/aborting its document requests to simulate slow or dead
+ * embeds. Event assertions read window.__connectionLostEvents, populated in
+ * src/utils/openfortConfig.ts.
+ */
+
+// Every test starts logged out — connection lifecycle is the subject here.
+test.use({
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture requires object destructuring
+  storageState: [async ({}, use) => use(undefined), { scope: 'test' }],
+})
+
+// The embed document URL is <iframe-host>/iframe/<publishable key>.
+const isIframeDocument = (url: URL) => url.pathname.startsWith('/iframe/')
+
+const getConnectionLostEvents = (page: Page): Promise<unknown[]> =>
+  page.evaluate(() => (window as unknown as { __connectionLostEvents?: unknown[] }).__connectionLostEvents ?? [])
+
+/** Recovery half of authenticateAndRecover, for re-recovery after failures. */
+async function recoverAutomatic(page: Page) {
+  await expect(page.locator('h1')).toContainText('Set up your embedded signer', { timeout: 60_000 })
+  await page.getByRole('button', { name: 'Use this wallet' }).click()
+  await expect(page.getByRole('heading', { name: 'Console' })).toBeVisible({ timeout: 90_000 })
+}
+
+test('handshake retry: recovers transparently when the first embed load is too slow', async ({ page }) => {
+  test.setTimeout(300_000)
+
+  let embedDocumentRequests = 0
+  await page.route(isIframeDocument, async (route) => {
+    embedDocumentRequests++
+    if (embedDocumentRequests === 1) {
+      // Hold the first embed document past the 10s handshake window. The SDK
+      // must abandon this iframe, recreate it, and complete on the retry.
+      await new Promise((resolve) => setTimeout(resolve, 15_000))
+      // The element was likely removed by the retry; the request may be gone.
+      await route.continue().catch(() => {})
+      return
+    }
+    await route.continue()
+  })
+
+  await authenticateAndRecover(page)
+
+  // The retry actually happened…
+  expect(embedDocumentRequests).toBeGreaterThanOrEqual(2)
+  // …silently: a loss the SDK recovered from on its own is not an event.
+  expect(await getConnectionLostEvents(page)).toEqual([])
+  // And exactly one live embed remains.
+  expect(await page.locator('#openfort-iframe').count()).toBe(1)
+})
+
+test('unreachable embed: exactly one connection-lost event, then full recovery once reachable', async ({ page }) => {
+  test.setTimeout(300_000)
+
+  let embedBlocked = true
+  await page.route(isIframeDocument, async (route) => {
+    if (embedBlocked) {
+      await route.abort()
+      return
+    }
+    await route.continue()
+  })
+
+  await authenticate(page)
+  await page.getByRole('button', { name: 'Use this wallet' }).click()
+
+  // Both handshake attempts (10s each) must fail, then emit EXACTLY ONE
+  // handshake-timeout event — not one per attempt.
+  await expect.poll(() => getConnectionLostEvents(page), { timeout: 90_000 }).toEqual([{ reason: 'handshake-timeout' }])
+
+  // Grace period: no duplicate events trickle in afterwards.
+  await page.waitForTimeout(5_000)
+  expect(await getConnectionLostEvents(page)).toHaveLength(1)
+
+  // Unblock the embed: the poisoned manager must be rebuilt from scratch and
+  // recovery must succeed — a transient outage must not require a logout.
+  embedBlocked = false
+  await page.reload()
+  await recoverAutomatic(page)
+})
+
+test('embed reloaded mid-session: reported exactly once, protocol noise stays silent', async ({ page }) => {
+  test.setTimeout(300_000)
+
+  await authenticateAndRecover(page)
+  expect(await getConnectionLostEvents(page)).toEqual([])
+
+  // Reload the embed page out from under the SDK (what browser memory
+  // pressure or an embed crash does). The child reconnects on its own.
+  await page.evaluate(() => {
+    const el = document.getElementById('openfort-iframe') as HTMLIFrameElement
+    // biome-ignore lint/correctness/noSelfAssign: assigning src reloads the frame
+    el.src = el.src
+  })
+
+  await expect.poll(() => getConnectionLostEvents(page), { timeout: 45_000 }).toEqual([{ reason: 'iframe-reloaded' }])
+
+  // The re-handshake involves duplicate protocol messages (double SYN/ACK);
+  // they must not produce additional events.
+  await page.waitForTimeout(8_000)
+  expect(await getConnectionLostEvents(page)).toHaveLength(1)
+})
+
+test('logout against a dead embed: bounded, completes, and is never reported as connection loss', async ({ page }) => {
+  test.setTimeout(300_000)
+
+  await authenticateAndRecover(page)
+
+  // Kill the embed: the penpal connection is now dangling and the logout RPC
+  // can never be answered.
+  await page.evaluate(() => {
+    document.getElementById('openfort-iframe')?.remove()
+  })
+
+  const startedAt = Date.now()
+  await page.getByRole('button', { name: 'Logout' }).first().click()
+  // The logout RPC is bounded at 10s — the flow must not hang on the dead embed.
+  await page.waitForURL('/login', { timeout: 30_000 })
+  expect(Date.now() - startedAt).toBeLessThan(30_000)
+
+  // An intentional teardown must not tell hosts the connection degraded —
+  // a host reacting (e.g. reloading a WebView) would race the logout itself.
+  await page.waitForTimeout(12_000)
+  expect(await getConnectionLostEvents(page)).toEqual([])
+})
+
+test('logout right after a page reload: flushes embed state and leaves no embed behind', async ({ page }) => {
+  test.setTimeout(300_000)
+
+  await authenticateAndRecover(page)
+
+  // Reload: in-memory signer/manager are gone, but the embed's persisted
+  // signer state (device share in its origin's localStorage) survives.
+  await page.reload()
+  await expect(page.getByRole('button', { name: 'Logout' }).first()).toBeVisible({ timeout: 30_000 })
+
+  await page.getByRole('button', { name: 'Logout' }).first().click()
+  await page.waitForURL('/login', { timeout: 30_000 })
+
+  // The best-effort flush may have created an embed to deliver the logout
+  // RPC — logout must clean it up either way.
+  await expect(page.locator('#openfort-iframe')).toHaveCount(0, { timeout: 15_000 })
+})
+
+test('repeated login/logout cycles: the connection rebuild survives churn', async ({ page }) => {
+  test.setTimeout(420_000)
+
+  for (let cycle = 1; cycle <= 2; cycle++) {
+    await authenticateAndRecover(page)
+
+    // The rebuilt connection must actually be usable, not just "recovered".
+    const logger = new Logger(page)
+    await logger.init()
+    const signButton = page.getByRole('button', { name: 'Sign Message' }).first()
+    await logger.clickAndWaitForNewLogs(() => signButton.click())
+    expect(logger.getLastLog()).toContain('0x')
+
+    await page.getByRole('button', { name: 'Logout' }).first().click()
+    await page.waitForURL('/login', { timeout: 30_000 })
+  }
+})

--- a/examples/apps/auth-sample/tests/connectionReliability.spec.ts
+++ b/examples/apps/auth-sample/tests/connectionReliability.spec.ts
@@ -6,20 +6,24 @@ import { Logger } from './Logger'
  * Non-happy-path stress tests for the iframe connection-reliability work
  * (branch fix/iframe-connection-reliability, SDK + embed):
  *
- * - handshake timeout → transparent one-shot retry (no spurious events)
+ * - handshake timeout → transparent one-shot retry (no spurious events),
+ *   then logout after a page reload → best-effort iframe flush + cleanup
  * - unreachable embed → typed failure, exactly ONE connection-lost event,
  *   and full recovery once the embed is reachable again
  * - embed page reloaded mid-session → exactly one 'iframe-reloaded' event
- *   (the deprecated-protocol duplicate-ACK path must stay silent)
- * - logout against a dead embed → bounded, and NEVER reported as a
+ *   (the deprecated-protocol duplicate-ACK path must stay silent), then
+ *   logout against a dead embed → bounded, and NEVER reported as a
  *   connection loss (intentional teardown)
- * - logout right after a page reload → best-effort iframe flush + cleanup
  * - repeated login/logout cycles → connection rebuild leaks nothing
  *
- * These tests run against the LOCAL embed dev server (NEXT_PUBLIC_IFRAME_URL),
- * intercepting/aborting its document requests to simulate slow or dead
- * embeds. Event assertions read window.__connectionLostEvents, populated in
- * src/utils/openfortConfig.ts.
+ * Scenarios that can safely share one authenticated session are chained into
+ * a single test — every full login+recovery costs ~1-2 minutes of serial CI
+ * time (the suite shares one test account, so nothing can parallelize).
+ *
+ * These tests intercept the embed's document requests to simulate slow or
+ * dead embeds; they work against both a local embed dev server
+ * (NEXT_PUBLIC_IFRAME_URL) and the production embed. Event assertions read
+ * window.__connectionLostEvents, populated in src/utils/openfortConfig.ts.
  */
 
 // Every test starts logged out — connection lifecycle is the subject here.
@@ -41,7 +45,7 @@ async function recoverAutomatic(page: Page) {
   await expect(page.getByRole('heading', { name: 'Console' })).toBeVisible({ timeout: 90_000 })
 }
 
-test('handshake retry: recovers transparently when the first embed load is too slow', async ({ page }) => {
+test('slow embed: silent handshake retry, then post-reload logout flushes and cleans up', async ({ page }) => {
   test.setTimeout(300_000)
 
   let embedDocumentRequests = 0
@@ -66,6 +70,18 @@ test('handshake retry: recovers transparently when the first embed load is too s
   expect(await getConnectionLostEvents(page)).toEqual([])
   // And exactly one live embed remains.
   expect(await page.locator('#openfort-iframe').count()).toBe(1)
+
+  // Phase 2 (same session): reload the page — in-memory signer/manager are
+  // gone, but the embed's persisted signer state (device share in its
+  // origin's localStorage) survives. Logout must best-effort flush it and
+  // leave no hidden embed behind.
+  await page.reload()
+  await expect(page.getByRole('button', { name: 'Logout' }).first()).toBeVisible({ timeout: 30_000 })
+
+  await page.getByRole('button', { name: 'Logout' }).first().click()
+  await page.waitForURL('/login', { timeout: 30_000 })
+
+  await expect(page.locator('#openfort-iframe')).toHaveCount(0, { timeout: 15_000 })
 })
 
 test('unreachable embed: exactly one connection-lost event, then full recovery once reachable', async ({ page }) => {
@@ -88,7 +104,7 @@ test('unreachable embed: exactly one connection-lost event, then full recovery o
   await expect.poll(() => getConnectionLostEvents(page), { timeout: 90_000 }).toEqual([{ reason: 'handshake-timeout' }])
 
   // Grace period: no duplicate events trickle in afterwards.
-  await page.waitForTimeout(5_000)
+  await page.waitForTimeout(4_000)
   expect(await getConnectionLostEvents(page)).toHaveLength(1)
 
   // Unblock the embed: the poisoned manager must be rebuilt from scratch and
@@ -98,7 +114,9 @@ test('unreachable embed: exactly one connection-lost event, then full recovery o
   await recoverAutomatic(page)
 })
 
-test('embed reloaded mid-session: reported exactly once, protocol noise stays silent', async ({ page }) => {
+test('embed reloaded mid-session reported exactly once, then logout against a dead embed stays bounded and silent', async ({
+  page,
+}) => {
   test.setTimeout(300_000)
 
   await authenticateAndRecover(page)
@@ -116,17 +134,11 @@ test('embed reloaded mid-session: reported exactly once, protocol noise stays si
 
   // The re-handshake involves duplicate protocol messages (double SYN/ACK);
   // they must not produce additional events.
-  await page.waitForTimeout(8_000)
+  await page.waitForTimeout(4_000)
   expect(await getConnectionLostEvents(page)).toHaveLength(1)
-})
 
-test('logout against a dead embed: bounded, completes, and is never reported as connection loss', async ({ page }) => {
-  test.setTimeout(300_000)
-
-  await authenticateAndRecover(page)
-
-  // Kill the embed: the penpal connection is now dangling and the logout RPC
-  // can never be answered.
+  // Phase 2 (same session): kill the embed outright — the penpal connection
+  // is now dangling and the logout RPC can never be answered.
   await page.evaluate(() => {
     document.getElementById('openfort-iframe')?.remove()
   })
@@ -139,26 +151,13 @@ test('logout against a dead embed: bounded, completes, and is never reported as 
 
   // An intentional teardown must not tell hosts the connection degraded —
   // a host reacting (e.g. reloading a WebView) would race the logout itself.
+  // Wait past the 10s logout-RPC budget so a late notify would be caught:
+  // no event beyond the earlier iframe-reloaded entry may appear. (Filter
+  // rather than compare exactly: a hard navigation on logout would reset the
+  // recorder to [], which is also a pass.)
   await page.waitForTimeout(12_000)
-  expect(await getConnectionLostEvents(page)).toEqual([])
-})
-
-test('logout right after a page reload: flushes embed state and leaves no embed behind', async ({ page }) => {
-  test.setTimeout(300_000)
-
-  await authenticateAndRecover(page)
-
-  // Reload: in-memory signer/manager are gone, but the embed's persisted
-  // signer state (device share in its origin's localStorage) survives.
-  await page.reload()
-  await expect(page.getByRole('button', { name: 'Logout' }).first()).toBeVisible({ timeout: 30_000 })
-
-  await page.getByRole('button', { name: 'Logout' }).first().click()
-  await page.waitForURL('/login', { timeout: 30_000 })
-
-  // The best-effort flush may have created an embed to deliver the logout
-  // RPC — logout must clean it up either way.
-  await expect(page.locator('#openfort-iframe')).toHaveCount(0, { timeout: 15_000 })
+  const events = (await getConnectionLostEvents(page)) as { reason?: string }[]
+  expect(events.filter((event) => event.reason !== 'iframe-reloaded')).toEqual([])
 })
 
 test('repeated login/logout cycles: the connection rebuild survives churn', async ({ page }) => {

--- a/examples/apps/auth-sample/tests/connectionReliability.spec.ts
+++ b/examples/apps/auth-sample/tests/connectionReliability.spec.ts
@@ -1,5 +1,4 @@
 import test, { expect, type Page } from '@playwright/test'
-import { authenticate, authenticateAndRecover } from './authenticate'
 import { Logger } from './Logger'
 
 /**
@@ -9,16 +8,18 @@ import { Logger } from './Logger'
  * - handshake timeout → transparent one-shot retry (no spurious events),
  *   then logout after a page reload → best-effort iframe flush + cleanup
  * - unreachable embed → typed failure, exactly ONE connection-lost event,
- *   and full recovery once the embed is reachable again
+ *   and wallet creation succeeds once the embed is reachable again
  * - embed page reloaded mid-session → exactly one 'iframe-reloaded' event
  *   (the deprecated-protocol duplicate-ACK path must stay silent), then
  *   logout against a dead embed → bounded, and NEVER reported as a
  *   connection loss (intentional teardown)
  * - repeated login/logout cycles → connection rebuild leaks nothing
  *
- * Scenarios that can safely share one authenticated session are chained into
- * a single test — every full login+recovery costs ~1-2 minutes of serial CI
- * time (the suite shares one test account, so nothing can parallelize).
+ * Every test signs up a FRESH GUEST account and creates its wallet through
+ * the automatic-recovery flow. That keeps this suite entirely off the shared
+ * E2E account the rest of the suite serializes around — so it runs in its
+ * own Playwright project (`reliability`), with parallel workers, in a CI job
+ * that runs concurrently with the main suite instead of extending it.
  *
  * These tests intercept the embed's document requests to simulate slow or
  * dead embeds; they work against both a local embed dev server
@@ -26,27 +27,38 @@ import { Logger } from './Logger'
  * window.__connectionLostEvents, populated in src/utils/openfortConfig.ts.
  */
 
-// Every test starts logged out — connection lifecycle is the subject here.
-test.use({
-  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture requires object destructuring
-  storageState: [async ({}, use) => use(undefined), { scope: 'test' }],
-})
-
 // The embed document URL is <iframe-host>/iframe/<publishable key>.
 const isIframeDocument = (url: URL) => url.pathname.startsWith('/iframe/')
 
 const getConnectionLostEvents = (page: Page): Promise<unknown[]> =>
   page.evaluate(() => (window as unknown as { __connectionLostEvents?: unknown[] }).__connectionLostEvents ?? [])
 
-/** Recovery half of authenticateAndRecover, for re-recovery after failures. */
-async function recoverAutomatic(page: Page) {
+/** Sign up a brand-new guest account and land on the wallet-setup screen. */
+async function signUpGuest(page: Page) {
+  await page.goto('/login')
+  await page.getByRole('button', { name: 'Continue as Guest' }).click()
+  await page.waitForURL('/', { timeout: 30_000 })
   await expect(page.locator('h1')).toContainText('Set up your embedded signer', { timeout: 60_000 })
-  await page.getByRole('button', { name: 'Use this wallet' }).click()
+}
+
+/**
+ * Create the guest's wallet via automatic recovery. This is the step that
+ * establishes the iframe connection (createSigner → handshake), so the
+ * interception scenarios anchor on it.
+ */
+async function createWalletAutomatic(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Create a new account' })).toBeVisible({ timeout: 30_000 })
+  await page.getByRole('button', { name: 'Set Automatic Recovery' }).click()
   await expect(page.getByRole('heading', { name: 'Console' })).toBeVisible({ timeout: 90_000 })
 }
 
+async function logout(page: Page) {
+  await page.getByRole('button', { name: 'Logout' }).first().click()
+  await page.waitForURL('/login', { timeout: 30_000 })
+}
+
 test('slow embed: silent handshake retry, then post-reload logout flushes and cleans up', async ({ page }) => {
-  test.setTimeout(300_000)
+  test.setTimeout(240_000)
 
   let embedDocumentRequests = 0
   await page.route(isIframeDocument, async (route) => {
@@ -62,7 +74,8 @@ test('slow embed: silent handshake retry, then post-reload logout flushes and cl
     await route.continue()
   })
 
-  await authenticateAndRecover(page)
+  await signUpGuest(page)
+  await createWalletAutomatic(page)
 
   // The retry actually happened…
   expect(embedDocumentRequests).toBeGreaterThanOrEqual(2)
@@ -77,15 +90,13 @@ test('slow embed: silent handshake retry, then post-reload logout flushes and cl
   // leave no hidden embed behind.
   await page.reload()
   await expect(page.getByRole('button', { name: 'Logout' }).first()).toBeVisible({ timeout: 30_000 })
-
-  await page.getByRole('button', { name: 'Logout' }).first().click()
-  await page.waitForURL('/login', { timeout: 30_000 })
+  await logout(page)
 
   await expect(page.locator('#openfort-iframe')).toHaveCount(0, { timeout: 15_000 })
 })
 
-test('unreachable embed: exactly one connection-lost event, then full recovery once reachable', async ({ page }) => {
-  test.setTimeout(300_000)
+test('unreachable embed: exactly one connection-lost event, then wallet creation once reachable', async ({ page }) => {
+  test.setTimeout(240_000)
 
   let embedBlocked = true
   await page.route(isIframeDocument, async (route) => {
@@ -96,8 +107,9 @@ test('unreachable embed: exactly one connection-lost event, then full recovery o
     await route.continue()
   })
 
-  await authenticate(page)
-  await page.getByRole('button', { name: 'Use this wallet' }).click()
+  await signUpGuest(page)
+  await expect(page.getByRole('heading', { name: 'Create a new account' })).toBeVisible({ timeout: 30_000 })
+  await page.getByRole('button', { name: 'Set Automatic Recovery' }).click()
 
   // Both handshake attempts (10s each) must fail, then emit EXACTLY ONE
   // handshake-timeout event — not one per attempt.
@@ -108,18 +120,20 @@ test('unreachable embed: exactly one connection-lost event, then full recovery o
   expect(await getConnectionLostEvents(page)).toHaveLength(1)
 
   // Unblock the embed: the poisoned manager must be rebuilt from scratch and
-  // recovery must succeed — a transient outage must not require a logout.
+  // wallet creation must succeed — a transient outage must not strand the
+  // account.
   embedBlocked = false
   await page.reload()
-  await recoverAutomatic(page)
+  await createWalletAutomatic(page)
 })
 
 test('embed reloaded mid-session reported exactly once, then logout against a dead embed stays bounded and silent', async ({
   page,
 }) => {
-  test.setTimeout(300_000)
+  test.setTimeout(240_000)
 
-  await authenticateAndRecover(page)
+  await signUpGuest(page)
+  await createWalletAutomatic(page)
   expect(await getConnectionLostEvents(page)).toEqual([])
 
   // Reload the embed page out from under the SDK (what browser memory
@@ -160,11 +174,12 @@ test('embed reloaded mid-session reported exactly once, then logout against a de
   expect(events.filter((event) => event.reason !== 'iframe-reloaded')).toEqual([])
 })
 
-test('repeated login/logout cycles: the connection rebuild survives churn', async ({ page }) => {
-  test.setTimeout(420_000)
+test('repeated signup/logout cycles: the connection rebuild survives churn', async ({ page }) => {
+  test.setTimeout(300_000)
 
   for (let cycle = 1; cycle <= 2; cycle++) {
-    await authenticateAndRecover(page)
+    await signUpGuest(page)
+    await createWalletAutomatic(page)
 
     // The rebuilt connection must actually be usable, not just "recovered".
     const logger = new Logger(page)
@@ -173,7 +188,6 @@ test('repeated login/logout cycles: the connection rebuild survives churn', asyn
     await logger.clickAndWaitForNewLogs(() => signButton.click())
     expect(logger.getLastLog()).toContain('0x')
 
-    await page.getByRole('button', { name: 'Logout' }).first().click()
-    await page.waitForURL('/login', { timeout: 30_000 })
+    await logout(page)
   }
 })

--- a/examples/apps/auth-sample/tests/walletRecovery.spec.ts
+++ b/examples/apps/auth-sample/tests/walletRecovery.spec.ts
@@ -15,6 +15,11 @@ const logout = async (page: Page) => {
   await page.waitForURL('/login')
 }
 
+// One retry is enough signal for this spec: at ~3-5 minutes per attempt it is
+// the single biggest wall-clock risk in the suite, and its known failure mode
+// (the shared account's embed-side recovery hang) does not go away on retry.
+test.describe.configure({ retries: process.env.CI ? 1 : 0 })
+
 test('Password recovery', async ({ page }) => {
   // Heaviest test in the suite: ~3 full auth cycles + 2 recovery-method changes +
   // wallet ops, all sequential. ~47s locally but ~4x slower on CI's networked runs.
@@ -74,7 +79,7 @@ test('Password recovery', async ({ page }) => {
     await passwordRecoveryButtonLogin.click()
 
     await expect(page.locator('div.spinner')).toBeInViewport()
-    await page.locator('div.spinner').waitFor({ state: 'hidden' })
+    await page.locator('div.spinner').waitFor({ state: 'hidden', timeout: 150_000 })
 
     const logger = new Logger(page)
     await logger.init()

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfort/openfort-js",
-  "version": "1.5.3",
+  "version": "1.5.2",
   "author": "Openfort (https://www.openfort.io)",
   "bugs": "https://github.com/openfort-xyz/openfort-js/issues",
   "repository": "openfort-xyz/openfort-js.git",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfort/openfort-js",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": "Openfort (https://www.openfort.io)",
   "bugs": "https://github.com/openfort-xyz/openfort-js/issues",
   "repository": "openfort-xyz/openfort-js.git",

--- a/sdk/src/__tests__/fixtures/storage.ts
+++ b/sdk/src/__tests__/fixtures/storage.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest'
+import type { IStorage } from '../../storage/istorage'
+
+/**
+ * Minimal IStorage mock shared by API/wallet unit tests. `get` resolves null
+ * by default — override per-test (e.g. `vi.mocked(storage.get).mockResolvedValue(...)`)
+ * to simulate persisted auth/account state.
+ */
+export function makeStorage(): IStorage {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    save: vi.fn(),
+    remove: vi.fn(),
+    flush: vi.fn(),
+  } as unknown as IStorage
+}

--- a/sdk/src/api/embeddedWallet.test.ts
+++ b/sdk/src/api/embeddedWallet.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeStorage } from '../__tests__/fixtures/storage'
 import { ConfigurationError } from '../core/errors/openfortError'
 import type { IStorage } from '../storage/istorage'
 import { StorageKeys } from '../storage/istorage'
@@ -42,15 +43,6 @@ vi.mock('../core/config/config', () => ({
 
 import { SDKConfiguration } from '../core/config/config'
 import { EmbeddedSigner } from '../wallets/embedded'
-
-function makeStorage(): IStorage {
-  return {
-    get: vi.fn().mockResolvedValue(null),
-    save: vi.fn(),
-    remove: vi.fn(),
-    flush: vi.fn(),
-  } as any
-}
 
 function makeEventEmitter() {
   return {
@@ -171,6 +163,31 @@ describe('getIframeManager() failure recovery', () => {
     expect(recreated).not.toBe(failed)
     expect(recreated).toBeInstanceOf(IframeManager)
   })
+
+  it('destroys the failed manager WITHOUT notifying the remote (RN child must stay connectable)', async () => {
+    const { api } = makeApi()
+    const failed = { hasFailed: true, destroy: vi.fn() }
+    ;(api as any).iframeManager = failed
+
+    await (api as any).getIframeManager()
+
+    expect(failed.destroy).toHaveBeenCalledWith({ notifyRemote: false })
+  })
+
+  it('clears the cached signer when recreating a failed manager, so no stale signer wraps the destroyed one', async () => {
+    // Recreation can be triggered outside ensureSigner (the RN onMessage
+    // path); a kept signer would dead-end every later operation in
+    // SessionEndedBeforeSetupError even though the replacement is healthy.
+    const { api } = makeApi()
+    const staleSigner = { disconnect: vi.fn() }
+    const failed = { hasFailed: true, destroy: vi.fn() }
+    ;(api as any).signer = staleSigner
+    ;(api as any).iframeManager = failed
+
+    await (api as any).getIframeManager()
+
+    expect((api as any).signer).toBeNull()
+  })
 })
 
 describe('createSigner() handshake retry', () => {
@@ -198,9 +215,14 @@ describe('createSigner() handshake retry', () => {
     // First attempt used managerA and failed; the retry must have torn A down
     // (via getIframeManager's hasFailed path) and initialized a fresh manager.
     expect(managerA.initialize).toHaveBeenCalledTimes(1)
+    // The first attempt suppresses the connection-lost notification (the SDK
+    // is about to retry transparently); the retry initializes unsuppressed so
+    // a final failure still emits exactly one event.
+    expect(managerA.initialize).toHaveBeenCalledWith({ suppressConnectionLostNotify: true })
     expect(managerA.destroy).toHaveBeenCalledTimes(1)
     expect(createSpy).toHaveBeenCalledTimes(1)
     expect(managerB.initialize).toHaveBeenCalledTimes(1)
+    expect(managerB.initialize).toHaveBeenCalledWith()
     expect(signer).toBeInstanceOf(EmbeddedSigner)
     expect((signer as any).iframeManager).toBe(managerB)
   })
@@ -266,17 +288,95 @@ describe('handleLogout()', () => {
     expect((api as any).provider).toBeNull()
   })
 
-  it('does not build a brand-new signer/iframe just to log out', async () => {
+  it('does not build a brand-new signer/iframe just to log out when no account was ever configured', async () => {
     const { api, storage } = makeApi()
     const createSpy = vi.spyOn(api as any, 'createIframeManager')
 
     await (api as any).handleLogout()
 
-    // No signer existed — logout must not spin up an iframe + handshake.
+    // No signer AND no stored account — there is no iframe-side state to
+    // flush, so logout must not spin up an iframe + handshake.
     expect(createSpy).not.toHaveBeenCalled()
     expect((api as any).iframeManager).toBeNull()
     expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
     expect(document.getElementById('openfort-iframe')).toBeNull()
+  })
+
+  it('flushes iframe-side state on logout after a page reload (stored account, no live connection)', async () => {
+    // The embed persists the device share in its origin's localStorage, which
+    // survives page reloads. A logout that skips the iframe logout RPC just
+    // because THIS page load never connected would leave that share on disk.
+    const { api, storage } = makeApi()
+    vi.mocked(storage.get).mockImplementation(async (key: string) =>
+      key === StorageKeys.ACCOUNT ? JSON.stringify({ id: 'acc_1', chainId: 1, address: '0xabc' }) : null
+    )
+    const manager = {
+      hasFailed: false,
+      isLoaded: () => false,
+      initialize: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn(),
+    }
+    const createSpy = vi.spyOn(api as any, 'createIframeManager').mockResolvedValue(manager)
+
+    await (api as any).handleLogout()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(manager.initialize).toHaveBeenCalledWith({ suppressConnectionLostNotify: true })
+    expect(manager.disconnect).toHaveBeenCalledTimes(1)
+    // Logout still completes its local teardown.
+    expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
+    expect((api as any).iframeManager).toBeNull()
+    expect((api as any).signer).toBeNull()
+  })
+
+  it('completes logout locally when the best-effort flush handshake fails', async () => {
+    const { api, storage } = makeApi()
+    vi.mocked(storage.get).mockImplementation(async (key: string) =>
+      key === StorageKeys.ACCOUNT ? JSON.stringify({ id: 'acc_1', chainId: 1, address: '0xabc' }) : null
+    )
+    const manager = {
+      hasFailed: false,
+      isLoaded: () => false,
+      initialize: vi.fn().mockRejectedValue(new IframeHandshakeTimeoutError(10_000, undefined)),
+      disconnect: vi.fn(),
+      destroy: vi.fn(),
+    }
+    vi.spyOn(api as any, 'createIframeManager').mockResolvedValue(manager)
+
+    await expect((api as any).handleLogout()).resolves.toBeUndefined()
+
+    expect(manager.disconnect).not.toHaveBeenCalled()
+    expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
+    expect((api as any).iframeManager).toBeNull()
+  })
+
+  it('destroys the manager silently in React Native mode (no penpal DESTROY to the WebView child)', async () => {
+    // A DESTROY makes the child remove its listeners permanently; the SDK
+    // cannot reload a WebView, so the next login would dead-end in handshake
+    // timeouts until the host remounts the WebView.
+    const { api } = makeApi()
+    const signer = { disconnect: vi.fn().mockResolvedValue(undefined) }
+    const manager = { hasFailed: false, isLoaded: () => true, destroy: vi.fn() }
+    ;(api as any).messagePoster = { postMessage: vi.fn() }
+    ;(api as any).signer = signer
+    ;(api as any).iframeManager = manager
+
+    await (api as any).handleLogout()
+
+    expect(manager.destroy).toHaveBeenCalledWith({ notifyRemote: false })
+  })
+
+  it('destroys the manager with remote notification in browser mode (disposable iframe child)', async () => {
+    const { api } = makeApi()
+    const signer = { disconnect: vi.fn().mockResolvedValue(undefined) }
+    const manager = { hasFailed: false, isLoaded: () => true, destroy: vi.fn() }
+    ;(api as any).signer = signer
+    ;(api as any).iframeManager = manager
+
+    await (api as any).handleLogout()
+
+    expect(manager.destroy).toHaveBeenCalledWith({ notifyRemote: true })
   })
 
   it('skips disconnect when the connection is not live, but still destroys and clears', async () => {

--- a/sdk/src/api/embeddedWallet.test.ts
+++ b/sdk/src/api/embeddedWallet.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConfigurationError } from '../core/errors/openfortError'
+import type { IStorage } from '../storage/istorage'
+import { StorageKeys } from '../storage/istorage'
+import { IframeHandshakeTimeoutError, IframeManager } from '../wallets/iframeManager'
+import { EmbeddedWalletApi } from './embeddedWallet'
+
+// Heavy leaf modules that EmbeddedWalletApi pulls in but these tests never
+// exercise — stub them so the import graph stays small and deterministic.
+vi.mock('@openfort/openapi-clients', () => ({
+  BackendApiClients: class {},
+}))
+vi.mock('core/passkey', () => ({
+  PasskeyHandler: { randomPasskeyName: () => 'passkey-test' },
+}))
+vi.mock('../wallets/embedded', () => ({
+  EmbeddedSigner: class {
+    constructor(public iframeManager: unknown) {}
+  },
+}))
+vi.mock('../wallets/evm', () => ({
+  EvmProvider: class {},
+}))
+vi.mock('../wallets/evm/provider/eip6963', () => ({
+  announceProvider: vi.fn(),
+  openfortProviderInfo: {},
+}))
+vi.mock('../wallets/evm/walletHelpers', () => ({
+  signMessage: vi.fn(),
+}))
+vi.mock('../core/errors/sentry', () => ({
+  sentry: {
+    captureException: vi.fn(),
+  },
+}))
+vi.mock('../core/config/config', () => ({
+  SDKConfiguration: {
+    getInstance: vi.fn(),
+  },
+}))
+
+import { SDKConfiguration } from '../core/config/config'
+import { EmbeddedSigner } from '../wallets/embedded'
+
+function makeStorage(): IStorage {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    save: vi.fn(),
+    remove: vi.fn(),
+    flush: vi.fn(),
+  } as any
+}
+
+function makeEventEmitter() {
+  return {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+  } as any
+}
+
+function makeApi(storage: IStorage = makeStorage()) {
+  const eventEmitter = makeEventEmitter()
+  const api = new EmbeddedWalletApi(
+    storage,
+    vi.fn().mockResolvedValue(undefined),
+    vi.fn().mockResolvedValue(undefined),
+    eventEmitter,
+    {} as any
+  )
+  return { api, storage, eventEmitter }
+}
+
+function stubConfiguration() {
+  vi.mocked(SDKConfiguration.getInstance).mockReturnValue({
+    iframeUrl: 'https://iframe.test/',
+    backendUrl: 'https://api.test',
+    shieldUrl: 'https://shield.test',
+    baseConfiguration: { publishableKey: 'pk_test_xyz' },
+    shieldConfiguration: { shieldPublishableKey: 'shield_test_xyz' },
+    nativeAppIdentifier: undefined,
+  } as any)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  stubConfiguration()
+  document.getElementById('openfort-iframe')?.remove()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ping() must not create an unconnected iframe', () => {
+  // An iframe created without a parent-side connect() leaves a child whose
+  // single handshake attempt expires before the first real operation — a
+  // probe API must never have that side effect.
+  it('returns false without creating a manager or iframe element when none exists', async () => {
+    const { api } = makeApi()
+
+    await expect(api.ping(0)).resolves.toBe(false)
+
+    expect((api as any).iframeManager).toBeNull()
+    expect(document.getElementById('openfort-iframe')).toBeNull()
+  })
+
+  it('returns false when a manager exists but is not loaded', async () => {
+    const { api } = makeApi()
+    ;(api as any).iframeManager = { isLoaded: () => false, hasFailed: false }
+
+    await expect(api.ping(0)).resolves.toBe(false)
+  })
+})
+
+describe('onMessage() in browser mode', () => {
+  it('ignores messages without creating a manager or iframe when no messagePoster is configured', async () => {
+    const { api } = makeApi()
+
+    await api.onMessage({ namespace: 'penpal', type: 'SYN' })
+
+    expect((api as any).iframeManager).toBeNull()
+    expect(document.getElementById('openfort-iframe')).toBeNull()
+  })
+})
+
+describe('createIframe()', () => {
+  it('creates the hidden iframe element when document.body is available', () => {
+    const { api } = makeApi()
+
+    const iframe = (api as any).createIframe('https://iframe.test/')
+
+    expect(iframe.id).toBe('openfort-iframe')
+    expect(document.getElementById('openfort-iframe')).toBe(iframe)
+  })
+
+  it('replaces an existing iframe element instead of stacking a second one', () => {
+    const { api } = makeApi()
+
+    const first = (api as any).createIframe('https://iframe.test/')
+    const second = (api as any).createIframe('https://iframe.test/')
+
+    expect(first).not.toBe(second)
+    expect(document.querySelectorAll('#openfort-iframe')).toHaveLength(1)
+  })
+
+  it('throws a clear ConfigurationError when document.body is not available', () => {
+    const { api } = makeApi()
+    const body = document.body
+    body.remove()
+
+    try {
+      expect(() => (api as any).createIframe('https://iframe.test/')).toThrow(ConfigurationError)
+      expect(() => (api as any).createIframe('https://iframe.test/')).toThrow(/document\.body is not available/)
+    } finally {
+      document.documentElement.appendChild(body)
+    }
+  })
+})
+
+describe('getIframeManager() failure recovery', () => {
+  it('destroys a failed manager before recreating, so its listeners/connection are released', async () => {
+    const { api } = makeApi()
+    const failed = { hasFailed: true, destroy: vi.fn() }
+    ;(api as any).iframeManager = failed
+
+    const recreated = await (api as any).getIframeManager()
+
+    expect(failed.destroy).toHaveBeenCalledTimes(1)
+    expect(recreated).not.toBe(failed)
+    expect(recreated).toBeInstanceOf(IframeManager)
+  })
+})
+
+describe('createSigner() handshake retry', () => {
+  it('retries once with a fresh iframe manager when the handshake times out', async () => {
+    const { api } = makeApi()
+
+    const managerA = {
+      hasFailed: false,
+      destroy: vi.fn(),
+      initialize: vi.fn().mockImplementation(() => {
+        managerA.hasFailed = true
+        return Promise.reject(new IframeHandshakeTimeoutError(10_000, undefined))
+      }),
+    }
+    const managerB = {
+      hasFailed: false,
+      destroy: vi.fn(),
+      initialize: vi.fn().mockResolvedValue(undefined),
+    }
+    ;(api as any).iframeManager = managerA
+    const createSpy = vi.spyOn(api as any, 'createIframeManager').mockResolvedValue(managerB)
+
+    const signer = await (api as any).createSigner()
+
+    // First attempt used managerA and failed; the retry must have torn A down
+    // (via getIframeManager's hasFailed path) and initialized a fresh manager.
+    expect(managerA.initialize).toHaveBeenCalledTimes(1)
+    expect(managerA.destroy).toHaveBeenCalledTimes(1)
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(managerB.initialize).toHaveBeenCalledTimes(1)
+    expect(signer).toBeInstanceOf(EmbeddedSigner)
+    expect((signer as any).iframeManager).toBe(managerB)
+  })
+
+  it('does not retry on non-timeout initialization failures', async () => {
+    const { api } = makeApi()
+
+    const managerA = {
+      hasFailed: false,
+      destroy: vi.fn(),
+      initialize: vi.fn().mockRejectedValue(new ConfigurationError('bad config')),
+    }
+    ;(api as any).iframeManager = managerA
+    const createSpy = vi.spyOn(api as any, 'createIframeManager')
+
+    await expect((api as any).createSigner()).rejects.toBeInstanceOf(ConfigurationError)
+
+    expect(managerA.initialize).toHaveBeenCalledTimes(1)
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the second timeout when the retry also fails', async () => {
+    const { api } = makeApi()
+
+    const makeTimingOutManager = () => {
+      const manager = {
+        hasFailed: false,
+        destroy: vi.fn(),
+        initialize: vi.fn().mockImplementation(() => {
+          manager.hasFailed = true
+          return Promise.reject(new IframeHandshakeTimeoutError(10_000, undefined))
+        }),
+      }
+      return manager
+    }
+    const managerA = makeTimingOutManager()
+    const managerB = makeTimingOutManager()
+    ;(api as any).iframeManager = managerA
+    vi.spyOn(api as any, 'createIframeManager').mockResolvedValue(managerB)
+
+    await expect((api as any).createSigner()).rejects.toBeInstanceOf(IframeHandshakeTimeoutError)
+
+    expect(managerA.initialize).toHaveBeenCalledTimes(1)
+    expect(managerB.initialize).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('handleLogout()', () => {
+  it('disconnects an existing live signer, destroys the manager, and clears all state', async () => {
+    const { api, storage } = makeApi()
+    const signer = { disconnect: vi.fn().mockResolvedValue(undefined) }
+    const manager = { hasFailed: false, isLoaded: () => true, destroy: vi.fn() }
+    ;(api as any).signer = signer
+    ;(api as any).iframeManager = manager
+
+    await (api as any).handleLogout()
+
+    expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
+    expect(signer.disconnect).toHaveBeenCalledTimes(1)
+    expect(manager.destroy).toHaveBeenCalledTimes(1)
+    expect((api as any).signer).toBeNull()
+    expect((api as any).iframeManager).toBeNull()
+    expect((api as any).provider).toBeNull()
+  })
+
+  it('does not build a brand-new signer/iframe just to log out', async () => {
+    const { api, storage } = makeApi()
+    const createSpy = vi.spyOn(api as any, 'createIframeManager')
+
+    await (api as any).handleLogout()
+
+    // No signer existed — logout must not spin up an iframe + handshake.
+    expect(createSpy).not.toHaveBeenCalled()
+    expect((api as any).iframeManager).toBeNull()
+    expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
+    expect(document.getElementById('openfort-iframe')).toBeNull()
+  })
+
+  it('skips disconnect when the connection is not live, but still destroys and clears', async () => {
+    const { api } = makeApi()
+    const signer = { disconnect: vi.fn() }
+    const manager = { hasFailed: false, isLoaded: () => false, destroy: vi.fn() }
+    ;(api as any).signer = signer
+    ;(api as any).iframeManager = manager
+
+    await (api as any).handleLogout()
+
+    expect(signer.disconnect).not.toHaveBeenCalled()
+    expect(manager.destroy).toHaveBeenCalledTimes(1)
+    expect((api as any).signer).toBeNull()
+  })
+
+  it('still clears state when disconnect rejects (e.g. logout RPC timeout)', async () => {
+    const { api } = makeApi()
+    const signer = { disconnect: vi.fn().mockRejectedValue(new Error('logout timed out')) }
+    const manager = { hasFailed: false, isLoaded: () => true, destroy: vi.fn() }
+    ;(api as any).signer = signer
+    ;(api as any).iframeManager = manager
+
+    await (api as any).handleLogout()
+
+    expect(manager.destroy).toHaveBeenCalledTimes(1)
+    expect((api as any).signer).toBeNull()
+    expect((api as any).iframeManager).toBeNull()
+  })
+})

--- a/sdk/src/api/embeddedWallet.test.ts
+++ b/sdk/src/api/embeddedWallet.test.ts
@@ -408,12 +408,8 @@ describe('handleLogout()', () => {
   })
 
   it('keeps the EvmProvider across logout (it subscribes to the shared emitter)', async () => {
-    // The provider registers ON_LOGOUT/ON_SWITCH_ACCOUNT/CONNECTION_LOST
-    // handlers on the shared emitter in its constructor and is announced via
-    // EIP-6963 (external code holds the instance). Dropping it on logout made
-    // every login cycle construct a new provider whose subscriptions
-    // accumulated on the emitter without bound; the provider is designed to
-    // survive logout (its own ON_LOGOUT handler clears the cached signer).
+    // The provider subscribes to the shared emitter and is held externally
+    // via EIP-6963, so it must survive logout; only connection state clears.
     const { api } = makeApi()
     const signer = { disconnect: vi.fn().mockResolvedValue(undefined) }
     const manager = { hasFailed: false, isLoaded: () => true, destroy: vi.fn() }

--- a/sdk/src/api/embeddedWallet.test.ts
+++ b/sdk/src/api/embeddedWallet.test.ts
@@ -406,6 +406,29 @@ describe('handleLogout()', () => {
     expect((api as any).signer).toBeNull()
     expect((api as any).iframeManager).toBeNull()
   })
+
+  it('keeps the EvmProvider across logout (it subscribes to the shared emitter)', async () => {
+    // The provider registers ON_LOGOUT/ON_SWITCH_ACCOUNT/CONNECTION_LOST
+    // handlers on the shared emitter in its constructor and is announced via
+    // EIP-6963 (external code holds the instance). Dropping it on logout made
+    // every login cycle construct a new provider whose subscriptions
+    // accumulated on the emitter without bound; the provider is designed to
+    // survive logout (its own ON_LOGOUT handler clears the cached signer).
+    const { api } = makeApi()
+    const signer = { disconnect: vi.fn().mockResolvedValue(undefined) }
+    const manager = { hasFailed: false, isLoaded: () => true, destroy: vi.fn() }
+    const provider = { marker: 'provider' }
+    ;(api as any).signer = signer
+    ;(api as any).iframeManager = manager
+    ;(api as any).provider = provider
+
+    await (api as any).handleLogout()
+
+    expect((api as any).provider).toBe(provider)
+    // The connection-scoped state is still cleared.
+    expect((api as any).signer).toBeNull()
+    expect((api as any).iframeManager).toBeNull()
+  })
 })
 
 describe('connection-lost event wiring', () => {

--- a/sdk/src/api/embeddedWallet.test.ts
+++ b/sdk/src/api/embeddedWallet.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConfigurationError } from '../core/errors/openfortError'
 import type { IStorage } from '../storage/istorage'
 import { StorageKeys } from '../storage/istorage'
+import { OpenfortEvents } from '../types/types'
 import { IframeHandshakeTimeoutError, IframeManager } from '../wallets/iframeManager'
 import { EmbeddedWalletApi } from './embeddedWallet'
 
@@ -304,5 +305,21 @@ describe('handleLogout()', () => {
     expect(manager.destroy).toHaveBeenCalledTimes(1)
     expect((api as any).signer).toBeNull()
     expect((api as any).iframeManager).toBeNull()
+  })
+})
+
+describe('connection-lost event wiring', () => {
+  it('emits ON_EMBEDDED_WALLET_CONNECTION_LOST when the manager reports a degraded connection', async () => {
+    const { api, eventEmitter } = makeApi()
+    await api.setMessagePoster({ postMessage: vi.fn() })
+
+    const manager = await (api as any).createIframeManager()
+
+    // Fire the hook the way IframeManager does on an RPC timeout.
+    ;(manager as any).callbacks.onConnectionLost('rpc-timeout')
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith(OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST, {
+      reason: 'rpc-timeout',
+    })
   })
 })

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -957,7 +957,6 @@ export class EmbeddedWalletApi {
     // Skip signer disconnect since there's no iframe/WebView storage to clear
     if (typeof document === 'undefined' && !this.messagePoster) {
       debugLog('Skipping signer disconnect: no messagePoster available in non-browser environment')
-      this.provider = null
       this.messenger = null
       this.iframeManager = null
       this.iframeManagerPromise = null
@@ -996,7 +995,12 @@ export class EmbeddedWalletApi {
       document.getElementById('openfort-iframe')?.remove()
     }
 
-    this.provider = null
+    // The EvmProvider is deliberately NOT dropped here. It subscribes to the
+    // shared event emitter in its constructor and is announced via EIP-6963
+    // (external code holds the instance across sessions), so recreating it per
+    // login cycle accumulated listeners on the shared emitter without bound.
+    // Its own ON_LOGOUT handler clears the cached signer and emits disconnect;
+    // the next request rebuilds through ensureSigner.
     this.messenger = null
     this.iframeManager = null
     this.iframeManagerPromise = null

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -34,7 +34,7 @@ import { EvmProvider, type Provider } from '../wallets/evm'
 import { announceProvider, openfortProviderInfo } from '../wallets/evm/provider/eip6963'
 import type { TypedDataPayload } from '../wallets/evm/types'
 import { signMessage } from '../wallets/evm/walletHelpers'
-import { IframeManager, type SignerConfigureRequest } from '../wallets/iframeManager'
+import { IframeHandshakeTimeoutError, IframeManager, type SignerConfigureRequest } from '../wallets/iframeManager'
 import { ReactNativeMessenger } from '../wallets/messaging'
 import { WindowMessenger } from '../wallets/messaging/browserMessenger'
 import type { MessagePoster } from '../wallets/types'
@@ -85,6 +85,12 @@ export class EmbeddedWalletApi {
     // Check if existing instance has failed - if so, clear it for recreation
     if (this.iframeManager?.hasFailed) {
       debugLog('[HANDSHAKE DEBUG] Existing iframeManager has failed, clearing for recreation')
+      // Tear the failed manager down before discarding it. In browser mode
+      // the WindowMessenger is owned by the manager's connection — without
+      // this, its window 'message' listener and MessagePort leak on every
+      // failure cycle and any in-flight RPCs on the old connection hang
+      // forever instead of rejecting.
+      this.iframeManager.destroy()
       if (this.messenger) {
         this.messenger.destroy()
         this.messenger = null
@@ -204,10 +210,26 @@ export class EmbeddedWalletApi {
   }
 
   private async createSigner(): Promise<EmbeddedSigner> {
-    const iframeManager = await this.getIframeManager()
+    let iframeManager = await this.getIframeManager()
     // Eagerly initialize the iframe connection so the penpal handshake completes
     // before any WebAuthn dialogs can block the event loop.
-    await iframeManager.initialize()
+    try {
+      await iframeManager.initialize()
+    } catch (error) {
+      if (!(error instanceof IframeHandshakeTimeoutError)) {
+        throw error
+      }
+      // One automatic retry with a fresh iframe before surfacing the timeout.
+      // A handshake timeout usually means the embed page loaded too slowly for
+      // the window, or the child's own single connection attempt had already
+      // expired (iframe created earlier without a parent listener). The failed
+      // manager is marked hasFailed, so getIframeManager() tears it down and
+      // recreates the iframe element — reloading the child page and giving the
+      // handshake a full fresh window.
+      debugLog('[HANDSHAKE DEBUG] Handshake timed out, retrying once with a fresh iframe')
+      iframeManager = await this.getIframeManager()
+      await iframeManager.initialize()
+    }
     const signer = new EmbeddedSigner(
       iframeManager,
       this.storage,
@@ -222,6 +244,15 @@ export class EmbeddedWalletApi {
     if (typeof document === 'undefined') {
       throw new ConfigurationError(
         'Document is not available. Please provide a message poster for non-browser environments.'
+      )
+    }
+
+    if (!document.body) {
+      // Without this guard, appendChild below throws a bare TypeError that is
+      // hard to trace back to "the SDK ran before <body> was parsed".
+      throw new ConfigurationError(
+        'document.body is not available yet. Initialize the embedded wallet after the document has loaded ' +
+          '(e.g. defer SDK initialization or run it from a script at the end of <body>).'
       )
     }
 
@@ -819,8 +850,13 @@ export class EmbeddedWalletApi {
         })
       }
 
-      const iframeManager = await this.getIframeManager()
-      if (!iframeManager.isLoaded()) {
+      // Deliberately do NOT call getIframeManager() here: it would create the
+      // iframe element without connecting to it. The child page connects once
+      // at load with a bounded handshake timeout — an iframe created by a
+      // probe and left unconnected produces a child that has already given up
+      // by the time the first real operation starts its handshake.
+      const iframeManager = this.iframeManager
+      if (!iframeManager?.isLoaded()) {
         return false
       }
 
@@ -885,9 +921,21 @@ export class EmbeddedWalletApi {
       return
     }
     try {
-      const signer = await this.ensureSigner()
-      await signer.disconnect()
+      // Only disconnect a signer that already exists over a live connection.
+      // Building a brand-new iframe + handshake just to tell it to log out
+      // (the old `ensureSigner()` behavior) is wasted work and can stall the
+      // logout flow behind a 10s handshake. The iframe-side state we'd clear
+      // doesn't exist yet if no connection was ever established.
+      if (this.signer && this.iframeManager?.isLoaded()) {
+        // disconnect() is bounded by the logout RPC timeout in IframeManager,
+        // so a frozen iframe cannot hang the logout flow indefinitely.
+        await this.signer.disconnect()
+      }
     } catch {}
+
+    // Tear down the manager (window listener, MessagePort, iframe connection)
+    // rather than just dropping the reference — see getIframeManager().
+    this.iframeManager?.destroy()
 
     this.provider = null
     this.messenger = null
@@ -904,6 +952,16 @@ export class EmbeddedWalletApi {
     }
 
     debugLog('[HANDSHAKE DEBUG] EmbeddedWalletApi onMessage:', message)
+
+    // onMessage is the React Native WebView entry point. In browser mode
+    // (no messagePoster) there is nothing to route the message to — and
+    // falling through to getIframeManager() would create an iframe element
+    // without ever connecting to it, leaving a child whose one connection
+    // attempt times out before the first real operation.
+    if (!this.messagePoster) {
+      debugLog('[HANDSHAKE DEBUG] onMessage ignored: no messagePoster configured (browser mode)')
+      return
+    }
 
     // Check if this is a penpal message
     const isPenpalMessage =

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -190,11 +190,8 @@ export class EmbeddedWalletApi {
     debugLog('[HANDSHAKE DEBUG] Creating IframeManager instance')
     return new IframeManager(configuration, this.storage, messenger, {
       onConnectionLost: (reason) => {
-        // Surface connection-health transitions to consumers. Hosts use this
-        // to react to an unresponsive embed — e.g. a React Native app may
-        // reload its hidden WebView on 'rpc-timeout'/'handshake-timeout'.
-        // For 'iframe-reloaded' the transport has ALREADY recovered and hosts
-        // must not reload in reaction (see the event's JSDoc).
+        // Surface connection-health transitions to consumers — see the
+        // event's JSDoc for the per-reason semantics hosts must follow.
         this.eventEmitter.emit(OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST, { reason })
       },
     })

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -39,6 +39,15 @@ import { ReactNativeMessenger } from '../wallets/messaging'
 import { WindowMessenger } from '../wallets/messaging/browserMessenger'
 import type { MessagePoster } from '../wallets/types'
 
+/**
+ * Deadline for the best-effort handshake during a logout that has no live
+ * connection (see flushIframeStateOnLogout). Deliberately shorter than the
+ * regular 10s handshake window: an unreachable embed must not hold the logout
+ * flow hostage, and the flush is opportunistic — local logout proceeds either
+ * way.
+ */
+const LOGOUT_FLUSH_HANDSHAKE_DEADLINE_MS = 5_000
+
 export class EmbeddedWalletApi {
   private iframeManager: IframeManager | null = null
 
@@ -90,12 +99,21 @@ export class EmbeddedWalletApi {
       // this, its window 'message' listener and MessagePort leak on every
       // failure cycle and any in-flight RPCs on the old connection hang
       // forever instead of rejecting.
-      this.iframeManager.destroy()
+      // Never notify the remote from this internal rebuild path: in React
+      // Native a penpal DESTROY permanently deafens the WebView child (it
+      // cannot be reloaded from here), dead-ending every later handshake.
+      this.iframeManager.destroy({ notifyRemote: false })
       if (this.messenger) {
         this.messenger.destroy()
         this.messenger = null
       }
       this.iframeManager = null
+      // The cached signer wraps the manager just destroyed. Recreation can be
+      // triggered outside ensureSigner (e.g. the React Native onMessage
+      // path), and ensureSigner's refresh check only inspects the CURRENT
+      // manager — the fresh, healthy replacement — so a stale signer kept
+      // here would dead-end every operation in SessionEndedBeforeSetupError.
+      this.signer = null
     }
 
     // Return existing instance if available and not failed
@@ -173,8 +191,10 @@ export class EmbeddedWalletApi {
     return new IframeManager(configuration, this.storage, messenger, {
       onConnectionLost: (reason) => {
         // Surface connection-health transitions to consumers. Hosts use this
-        // to react to an unresponsive or reloaded embed — e.g. the React
-        // Native SDK reloads its hidden WebView.
+        // to react to an unresponsive embed — e.g. a React Native app may
+        // reload its hidden WebView on 'rpc-timeout'/'handshake-timeout'.
+        // For 'iframe-reloaded' the transport has ALREADY recovered and hosts
+        // must not reload in reaction (see the event's JSDoc).
         this.eventEmitter.emit(OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST, { reason })
       },
     })
@@ -221,18 +241,26 @@ export class EmbeddedWalletApi {
     // Eagerly initialize the iframe connection so the penpal handshake completes
     // before any WebAuthn dialogs can block the event loop.
     try {
-      await iframeManager.initialize()
+      // Suppress the connection-lost notification for this first attempt: a
+      // timeout here is retried transparently below, and hosts must not react
+      // (e.g. reload a WebView) to a loss the SDK is about to recover from.
+      // The retry initializes unsuppressed, so a final failure still emits
+      // exactly one event.
+      await iframeManager.initialize({ suppressConnectionLostNotify: true })
     } catch (error) {
       if (!(error instanceof IframeHandshakeTimeoutError)) {
         throw error
       }
-      // One automatic retry with a fresh iframe before surfacing the timeout.
+      // One automatic retry with a fresh manager before surfacing the timeout.
       // A handshake timeout usually means the embed page loaded too slowly for
-      // the window, or the child's own single connection attempt had already
-      // expired (iframe created earlier without a parent listener). The failed
-      // manager is marked hasFailed, so getIframeManager() tears it down and
-      // recreates the iframe element — reloading the child page and giving the
-      // handshake a full fresh window.
+      // the window, or the child's own connection attempt had already expired.
+      // The failed manager is marked hasFailed, so getIframeManager() tears it
+      // down and recreates it. In browser mode that recreates the iframe
+      // element, reloading the child page for a fresh handshake window. In
+      // React Native mode only the messenger is recreated (the WebView cannot
+      // be reloaded from here) — the retry still helps because the child
+      // retries its own handshake every ~10.5s, so the second window can
+      // catch its next attempt.
       debugLog('[HANDSHAKE DEBUG] Handshake timed out, retrying once with a fresh iframe')
       iframeManager = await this.getIframeManager()
       await iframeManager.initialize()
@@ -911,6 +939,16 @@ export class EmbeddedWalletApi {
   }
 
   private async handleLogout(): Promise<void> {
+    // A configured account means a PRIOR session's connection may have left
+    // signer state persisted inside the embed (the device share in the iframe
+    // origin's localStorage survives page reloads), even if this page load
+    // never connected. Capture before clearing so we know whether a
+    // best-effort iframe-side flush is warranted below.
+    let hadConfiguredAccount = false
+    try {
+      hadConfiguredAccount = (await Account.fromStorage(this.storage)) !== null
+    } catch {}
+
     // Clear Account from storage first — ensures getEmbeddedState() returns
     // EMBEDDED_SIGNER_NOT_CONFIGURED on next login even if iframe disconnect fails
     this.storage.remove(StorageKeys.ACCOUNT)
@@ -928,21 +966,35 @@ export class EmbeddedWalletApi {
       return
     }
     try {
-      // Only disconnect a signer that already exists over a live connection.
-      // Building a brand-new iframe + handshake just to tell it to log out
-      // (the old `ensureSigner()` behavior) is wasted work and can stall the
-      // logout flow behind a 10s handshake. The iframe-side state we'd clear
-      // doesn't exist yet if no connection was ever established.
       if (this.signer && this.iframeManager?.isLoaded()) {
+        // Live connection: tell the embed to flush its signer state.
         // disconnect() is bounded by the logout RPC timeout in IframeManager,
         // so a frozen iframe cannot hang the logout flow indefinitely.
         await this.signer.disconnect()
+      } else if (hadConfiguredAccount) {
+        // No live connection (e.g. the page reloaded since the wallet was
+        // configured), but the embed may still hold persisted signer state
+        // from the session that configured it. Best-effort, time-boxed flush
+        // — never allowed to block or fail the logout (this catch swallows
+        // everything, and the handshake attempt is raced against a deadline).
+        await this.flushIframeStateOnLogout()
       }
     } catch {}
 
     // Tear down the manager (window listener, MessagePort, iframe connection)
     // rather than just dropping the reference — see getIframeManager().
-    this.iframeManager?.destroy()
+    // In React Native the remote must NOT be notified: a penpal DESTROY makes
+    // the WebView child remove its message listeners permanently (the child
+    // connects once and the SDK cannot reload a WebView), bricking every
+    // subsequent login until the host remounts the WebView.
+    this.iframeManager?.destroy({ notifyRemote: !this.messagePoster })
+
+    // Drop the hidden iframe element too (browser mode): after destroy() the
+    // child page can never reconnect to this manager, and a best-effort flush
+    // above may have created the element on a page that otherwise had none.
+    if (typeof document !== 'undefined') {
+      document.getElementById('openfort-iframe')?.remove()
+    }
 
     this.provider = null
     this.messenger = null
@@ -950,6 +1002,39 @@ export class EmbeddedWalletApi {
     this.iframeManagerPromise = null
     this.signer = null
     this.signerPromise = null
+  }
+
+  /**
+   * Best-effort flush of the embed's persisted signer state during a logout
+   * that has no live connection. Bounded twice over: the handshake attempt is
+   * raced against a short deadline so an unreachable embed cannot stall the
+   * logout, and the logout RPC itself is bounded inside IframeManager. Errors
+   * propagate to handleLogout's catch — logout always completes locally.
+   */
+  private async flushIframeStateOnLogout(): Promise<void> {
+    const manager = await this.getIframeManager()
+    // Suppress connection-lost notification: this is an opportunistic flush
+    // during logout — hosts must not react to its failure.
+    const initPromise = manager.initialize({ suppressConnectionLostNotify: true })
+    // The race below can abandon initPromise (deadline elapsed; the destroy()
+    // in handleLogout rejects it later) — pre-attach a handler so the
+    // abandoned rejection is not an unhandled rejection.
+    initPromise.catch(() => {})
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        initPromise,
+        new Promise<never>((_, reject) => {
+          deadlineTimer = setTimeout(
+            () => reject(new Error('Logout iframe flush: handshake deadline elapsed')),
+            LOGOUT_FLUSH_HANDSHAKE_DEADLINE_MS
+          )
+        }),
+      ])
+    } finally {
+      clearTimeout(deadlineTimer)
+    }
+    await manager.disconnect()
   }
 
   async onMessage(message: Record<string, unknown>): Promise<void> {
@@ -977,7 +1062,7 @@ export class EmbeddedWalletApi {
 
     // If we have a ReactNativeMessenger already created, pass the message directly to it
     // This handles the case where synAck arrives while IframeManager is still initializing
-    if (isPenpalMessage && this.messenger && this.messagePoster) {
+    if (isPenpalMessage && this.messenger) {
       debugLog('[HANDSHAKE DEBUG] Passing message directly to existing ReactNativeMessenger')
       this.messenger.handleMessage(message)
       return

--- a/sdk/src/api/embeddedWallet.ts
+++ b/sdk/src/api/embeddedWallet.ts
@@ -170,7 +170,14 @@ export class EmbeddedWalletApi {
     }
 
     debugLog('[HANDSHAKE DEBUG] Creating IframeManager instance')
-    return new IframeManager(configuration, this.storage, messenger)
+    return new IframeManager(configuration, this.storage, messenger, {
+      onConnectionLost: (reason) => {
+        // Surface connection-health transitions to consumers. Hosts use this
+        // to react to an unresponsive or reloaded embed — e.g. the React
+        // Native SDK reloads its hidden WebView.
+        this.eventEmitter.emit(OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST, { reason })
+      },
+    })
   }
 
   /**

--- a/sdk/src/core/openfort.ts
+++ b/sdk/src/core/openfort.ts
@@ -166,9 +166,9 @@ export class Openfort {
       }
 
       // Forward all event types. Derived from the OpenfortEvents enum so a
-      // newly added event cannot be silently missing from the global emitter
-      // (a hardcoded copy of the list previously dropped new events). The UI
-      // flow events are not enum members yet, so they are appended explicitly.
+      // newly added event cannot be silently missing from the global emitter.
+      // The UI flow events are not enum members yet, so they are appended
+      // explicitly.
       const events: (keyof OpenfortEventMap)[] = [
         ...Object.values(OpenfortEvents),
         'onAuthFlowOpen',

--- a/sdk/src/core/openfort.ts
+++ b/sdk/src/core/openfort.ts
@@ -7,7 +7,7 @@ import { UserApi } from '../api/user'
 import { AuthManager } from '../auth/authManager'
 import { type IStorage, StorageKeys } from '../storage/istorage'
 import { LazyStorage } from '../storage/lazyStorage'
-import type { OpenfortEventMap } from '../types/types'
+import { type OpenfortEventMap, OpenfortEvents } from '../types/types'
 import TypedEventEmitter from '../utils/typedEventEmitter'
 import { type OpenfortSDKConfiguration, SDKConfiguration } from './config/config'
 import { OPENFORT_AUTH_ERROR_CODES, OPENFORT_ERROR_CODES } from './errors/authErrorCodes'
@@ -165,16 +165,12 @@ export class Openfort {
         })
       }
 
-      // Forward all event types
+      // Forward all event types. Derived from the OpenfortEvents enum so a
+      // newly added event cannot be silently missing from the global emitter
+      // (a hardcoded copy of the list previously dropped new events). The UI
+      // flow events are not enum members yet, so they are appended explicitly.
       const events: (keyof OpenfortEventMap)[] = [
-        'onAuthInit',
-        'onAuthSuccess',
-        'onAuthFailure',
-        'onLogout',
-        'onSwitchAccount',
-        'onSignedMessage',
-        'onEmbeddedWalletCreated',
-        'onEmbeddedWalletRecovered',
+        ...Object.values(OpenfortEvents),
         'onAuthFlowOpen',
         'onAuthFlowClose',
         'onAuthFlowCancel',

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -44,6 +44,7 @@ export {
 } from '../wallets/evm/sessionTypes'
 export { Provider, TypedDataPayload } from '../wallets/evm/types'
 export {
+  IframeConnectionDestroyedError,
   IframeHandshakeTimeoutError,
   IframeRpcTimeoutError,
   IframeSignEmptyResponseError,
@@ -67,6 +68,7 @@ export {
   ChainTypeEnum,
   EmbeddedAccount,
   EmbeddedState,
+  EmbeddedWalletConnectionLostPayload,
   InitializeOAuthOptions,
   OAuthProvider,
   OpenfortEventMap,

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -45,6 +45,7 @@ export {
 export { Provider, TypedDataPayload } from '../wallets/evm/types'
 export {
   IframeHandshakeTimeoutError,
+  IframeRpcTimeoutError,
   IframeSignEmptyResponseError,
   IframeSignTimeoutError,
   MissingProjectEntropyError,

--- a/sdk/src/types/types.ts
+++ b/sdk/src/types/types.ts
@@ -38,6 +38,21 @@ export enum OpenfortEvents {
   ON_EMBEDDED_WALLET_CREATED = 'onEmbeddedWalletCreated',
   /** Called when an embedded wallet is recovered */
   ON_EMBEDDED_WALLET_RECOVERED = 'onEmbeddedWalletRecovered',
+  /**
+   * Called when the embedded wallet connection degrades: an RPC or handshake
+   * timed out (the iframe is unresponsive and will be rebuilt on the next
+   * operation), or the embed page reloaded mid-session and re-handshaked
+   * (transport recovered, but the iframe's in-memory signer state is gone).
+   * Hosts can react — e.g. a React Native app may reload its WebView.
+   */
+  ON_EMBEDDED_WALLET_CONNECTION_LOST = 'onEmbeddedWalletConnectionLost',
+}
+
+/**
+ * Payload for {@link OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST}
+ */
+export type EmbeddedWalletConnectionLostPayload = {
+  reason: 'rpc-timeout' | 'handshake-timeout' | 'iframe-reloaded'
 }
 
 /**
@@ -65,6 +80,7 @@ export interface OpenfortEventMap extends Record<string, any> {
   [OpenfortEvents.ON_SIGNED_MESSAGE]: [SignedMessagePayload]
   [OpenfortEvents.ON_EMBEDDED_WALLET_CREATED]: [EmbeddedAccount]
   [OpenfortEvents.ON_EMBEDDED_WALLET_RECOVERED]: [EmbeddedAccount]
+  [OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST]: [EmbeddedWalletConnectionLostPayload]
 }
 
 export enum RecoveryMethod {

--- a/sdk/src/types/types.ts
+++ b/sdk/src/types/types.ts
@@ -39,17 +39,26 @@ export enum OpenfortEvents {
   /** Called when an embedded wallet is recovered */
   ON_EMBEDDED_WALLET_RECOVERED = 'onEmbeddedWalletRecovered',
   /**
-   * Called when the embedded wallet connection degrades: an RPC or handshake
-   * timed out (the iframe is unresponsive and will be rebuilt on the next
-   * operation), or the embed page reloaded mid-session and re-handshaked
-   * (transport recovered, but the iframe's in-memory signer state is gone).
-   * Hosts can react — e.g. a React Native app may reload its WebView.
+   * Called when the embedded wallet connection degrades. React per reason —
+   * they mean different things:
+   *
+   * - `rpc-timeout`: an operation timed out; the iframe is unresponsive and
+   *   the SDK rebuilds the connection on the next operation. Hosts may react,
+   *   e.g. a React Native app reloading its hidden WebView.
+   * - `handshake-timeout`: the SDK could not establish the connection (where
+   *   an automatic retry applies, it has already been exhausted — this event
+   *   is not fired for attempts the SDK recovers from on its own).
+   * - `iframe-reloaded`: the embed page re-handshaked mid-session. The
+   *   transport has ALREADY recovered — do NOT reload the embed/WebView in
+   *   reaction — but the iframe's in-memory signer state may be gone, so the
+   *   next operation can require re-configuration.
    */
   ON_EMBEDDED_WALLET_CONNECTION_LOST = 'onEmbeddedWalletConnectionLost',
 }
 
 /**
- * Payload for {@link OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST}
+ * Payload for {@link OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST}.
+ * See the event's JSDoc for the per-reason semantics.
  */
 export type EmbeddedWalletConnectionLostPayload = {
   reason: 'rpc-timeout' | 'handshake-timeout' | 'iframe-reloaded'

--- a/sdk/src/version.ts
+++ b/sdk/src/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = '1.5.3'
+export const VERSION = '1.5.2'
 export const PACKAGE = '@openfort/openfort-js'

--- a/sdk/src/version.ts
+++ b/sdk/src/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = '1.5.2'
+export const VERSION = '1.5.3'
 export const PACKAGE = '@openfort/openfort-js'

--- a/sdk/src/wallets/embedded.test.ts
+++ b/sdk/src/wallets/embedded.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makeStorage } from '../__tests__/fixtures/storage'
+import { StorageKeys } from '../storage/istorage'
+
+// Heavy leaf modules EmbeddedSigner pulls in but these tests never exercise.
+vi.mock('@openfort/openapi-clients', () => ({
+  BackendApiClients: class {},
+}))
+vi.mock('core/passkey', () => ({
+  PasskeyHandler: class {},
+}))
+
+import { EmbeddedSigner } from './embedded'
+
+describe('EmbeddedSigner.disconnect', () => {
+  it('clears the stored account even when the iframe logout RPC fails', async () => {
+    // disconnect() is best-effort cleanup: a frozen iframe's logout timeout
+    // (IframeRpcTimeoutError) must neither skip the local account removal nor
+    // reject callers that treat disconnect as teardown — revokeSession's
+    // no-permissionContext path awaits it with no try/catch of its own.
+    const storage = makeStorage()
+    const iframeManager = { disconnect: vi.fn().mockRejectedValue(new Error('logout timed out')) }
+    const signer = new EmbeddedSigner(iframeManager as any, storage, {} as any, {} as any, {} as any)
+
+    await expect(signer.disconnect()).resolves.toBeUndefined()
+
+    expect(iframeManager.disconnect).toHaveBeenCalledTimes(1)
+    expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
+  })
+
+  it('clears the stored account on a successful iframe logout', async () => {
+    const storage = makeStorage()
+    const iframeManager = { disconnect: vi.fn().mockResolvedValue(undefined) }
+    const signer = new EmbeddedSigner(iframeManager as any, storage, {} as any, {} as any, {} as any)
+
+    await signer.disconnect()
+
+    expect(storage.remove).toHaveBeenCalledWith(StorageKeys.ACCOUNT)
+  })
+})

--- a/sdk/src/wallets/embedded.ts
+++ b/sdk/src/wallets/embedded.ts
@@ -5,6 +5,7 @@ import { ConfigurationError, SessionError } from 'core/errors/openfortError'
 import { withApiError } from 'core/errors/withApiError'
 import type { IPasskeyHandler } from 'core/passkey'
 import { PasskeyHandler } from 'core/passkey'
+import { debugLog } from 'utils/debug'
 import type TypedEventEmitter from 'utils/typedEventEmitter'
 import { SDKConfiguration } from '../core/config/config'
 import { Account } from '../core/configuration/account'
@@ -440,7 +441,16 @@ export class EmbeddedSigner implements Signer {
   }
 
   async disconnect(): Promise<void> {
-    await this.iframeManager.disconnect()
+    try {
+      // Best-effort: bounded by the logout RPC timeout in IframeManager. A
+      // frozen iframe must not prevent the local account from being cleared
+      // below, nor fail callers that treat disconnect as cleanup (e.g.
+      // wallet_revokePermissions' no-permissionContext path awaits this with
+      // no try/catch of its own).
+      await this.iframeManager.disconnect()
+    } catch (error) {
+      debugLog('EmbeddedSigner.disconnect: iframe logout failed, continuing local cleanup:', error)
+    }
     this.storage.remove(StorageKeys.ACCOUNT)
   }
 }

--- a/sdk/src/wallets/evm/evmProvider.test.ts
+++ b/sdk/src/wallets/evm/evmProvider.test.ts
@@ -99,4 +99,17 @@ describe('EvmProvider signer cache vs connection loss', () => {
 
     expect(ensureSigner).toHaveBeenCalledTimes(2)
   })
+
+  it('drops the cached RPC provider on logout (chainId is account-derived; the instance now survives logout)', async () => {
+    const { provider, openfortEventEmitter } = makeCachedSignerProvider()
+
+    const before = await provider.getRpcProvider()
+    expect(await provider.getRpcProvider()).toBe(before)
+
+    openfortEventEmitter.emit(OpenfortEvents.ON_LOGOUT)
+
+    // The next session may be a different account on a different chain —
+    // serving the previous session's provider would hit the wrong network.
+    expect(await provider.getRpcProvider()).not.toBe(before)
+  })
 })

--- a/sdk/src/wallets/evm/evmProvider.test.ts
+++ b/sdk/src/wallets/evm/evmProvider.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
-import { EvmProvider } from './evmProvider'
+import { makeStorage } from '../../__tests__/fixtures/storage'
+import { OpenfortEvents } from '../../types/types'
+import TypedEventEmitter from '../../utils/typedEventEmitter'
 import { JsonRpcError } from './JsonRpcError'
+
+// The connection-loss tests only need personalSign to resolve; the real
+// implementation pulls in signing helpers they don't exercise.
+vi.mock('./personalSign', () => ({
+  personalSign: vi.fn().mockResolvedValue('0xsignature'),
+}))
+
+import { EvmProvider } from './evmProvider'
 
 // Build an EvmProvider whose signer initialization rejects asynchronously.
 // `eth_signTransaction` awaits `ensureSigner()` right after an (empty) storage
@@ -36,5 +46,57 @@ describe('EvmProvider.request error handling', () => {
     const inner = new JsonRpcError(4100, 'Unauthorized - call eth_requestAccounts first')
     const provider = makeProvider(() => Promise.reject(inner))
     await expect(provider.request({ method: 'eth_signTransaction', params: [{}] })).rejects.toBe(inner)
+  })
+})
+
+describe('EvmProvider signer cache vs connection loss', () => {
+  function makeCachedSignerProvider() {
+    const storage = makeStorage()
+    // personal_sign requires a stored account before it touches the signer.
+    vi.mocked(storage.get).mockResolvedValue(JSON.stringify({ id: 'acc_1', chainId: 1, address: '0xabc' }))
+
+    const openfortEventEmitter = new TypedEventEmitter<any>()
+    const ensureSigner = vi.fn(async () => ({}) as any)
+
+    const provider = new EvmProvider({
+      storage,
+      backendApiClients: {} as any,
+      openfortEventEmitter,
+      ensureSigner,
+      validateAndRefreshSession: vi.fn().mockResolvedValue(undefined),
+    })
+
+    return { provider, openfortEventEmitter, ensureSigner }
+  }
+
+  it('rebuilds the signer after ON_EMBEDDED_WALLET_CONNECTION_LOST instead of reusing the poisoned one', async () => {
+    // The injected ensureSigner (EmbeddedWalletApi) is what rebuilds a signer
+    // whose manager was poisoned by an RPC/handshake timeout. If the provider
+    // kept serving its cached signer, every provider call after a single
+    // timeout would dead-end in 'Previous connection attempt failed' until
+    // logout.
+    const { provider, openfortEventEmitter, ensureSigner } = makeCachedSignerProvider()
+
+    await provider.request({ method: 'personal_sign', params: ['0xmsg', '0xabc'] })
+    await provider.request({ method: 'personal_sign', params: ['0xmsg', '0xabc'] })
+
+    // Healthy connection: the signer is cached across requests.
+    expect(ensureSigner).toHaveBeenCalledTimes(1)
+
+    openfortEventEmitter.emit(OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST, { reason: 'rpc-timeout' })
+
+    await provider.request({ method: 'personal_sign', params: ['0xmsg', '0xabc'] })
+
+    expect(ensureSigner).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the cached signer on logout (existing behavior, kept)', async () => {
+    const { provider, openfortEventEmitter, ensureSigner } = makeCachedSignerProvider()
+
+    await provider.request({ method: 'personal_sign', params: ['0xmsg', '0xabc'] })
+    openfortEventEmitter.emit(OpenfortEvents.ON_LOGOUT)
+    await provider.request({ method: 'personal_sign', params: ['0xmsg', '0xabc'] })
+
+    expect(ensureSigner).toHaveBeenCalledTimes(2)
   })
 })

--- a/sdk/src/wallets/evm/evmProvider.test.ts
+++ b/sdk/src/wallets/evm/evmProvider.test.ts
@@ -90,7 +90,7 @@ describe('EvmProvider signer cache vs connection loss', () => {
     expect(ensureSigner).toHaveBeenCalledTimes(2)
   })
 
-  it('clears the cached signer on logout (existing behavior, kept)', async () => {
+  it('clears the cached signer on logout', async () => {
     const { provider, openfortEventEmitter, ensureSigner } = makeCachedSignerProvider()
 
     await provider.request({ method: 'personal_sign', params: ['0xmsg', '0xabc'] })
@@ -100,7 +100,7 @@ describe('EvmProvider signer cache vs connection loss', () => {
     expect(ensureSigner).toHaveBeenCalledTimes(2)
   })
 
-  it('drops the cached RPC provider on logout (chainId is account-derived; the instance now survives logout)', async () => {
+  it('drops the cached RPC provider on logout (its chainId is derived from the logged-in account)', async () => {
     const { provider, openfortEventEmitter } = makeCachedSignerProvider()
 
     const before = await provider.getRpcProvider()

--- a/sdk/src/wallets/evm/evmProvider.ts
+++ b/sdk/src/wallets/evm/evmProvider.ts
@@ -97,6 +97,7 @@ export class EvmProvider implements Provider {
 
     openfortEventEmitter.on(OpenfortEvents.ON_LOGOUT, this.#handleLogout)
     openfortEventEmitter.on(OpenfortEvents.ON_SWITCH_ACCOUNT, this.#handleSwitchAccount)
+    openfortEventEmitter.on(OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST, this.#handleConnectionLost)
   }
 
   #ensureSigner = async (): Promise<Signer> => {
@@ -104,6 +105,16 @@ export class EvmProvider implements Provider {
       this.#signer = await this.#ensureSignerFn()
     }
     return this.#signer
+  }
+
+  #handleConnectionLost = async () => {
+    // The iframe manager underneath the cached signer has been poisoned
+    // (RPC/handshake timeout) or superseded (embed reload). Drop the cache so
+    // the next request goes through the injected ensureSigner, which rebuilds
+    // against a fresh manager — otherwise every provider call keeps hitting
+    // the dead manager and throws 'Previous connection attempt failed' until
+    // logout.
+    this.#signer = undefined
   }
 
   #handleLogout = async () => {

--- a/sdk/src/wallets/evm/evmProvider.ts
+++ b/sdk/src/wallets/evm/evmProvider.ts
@@ -119,6 +119,9 @@ export class EvmProvider implements Provider {
 
   #handleLogout = async () => {
     this.#signer = undefined
+    // Session-scoped like the signer: the cached RPC provider is derived from
+    // the logged-in account's chainId, and this instance outlives logout.
+    this.#rpcProvider = null
     this.#eventEmitter.emit(ProviderEvent.DISCONNECT, { code: 4900, message: 'Disconnected' })
     this.#eventEmitter.emit(ProviderEvent.ACCOUNTS_CHANGED, [])
   }

--- a/sdk/src/wallets/iframeManager.test.ts
+++ b/sdk/src/wallets/iframeManager.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeStorage } from '../__tests__/fixtures/storage'
 import type { IStorage } from '../storage/istorage'
 import {
+  IframeConnectionDestroyedError,
   IframeHandshakeTimeoutError,
   IframeManager,
   IframeRpcTimeoutError,
@@ -82,15 +84,6 @@ function makeConfig() {
     backendUrl: 'https://api.test',
     shieldUrl: 'https://shield.test',
     nativeAppIdentifier: undefined,
-  } as any
-}
-
-function makeStorage(): IStorage {
-  return {
-    get: vi.fn().mockResolvedValue(null),
-    save: vi.fn(),
-    remove: vi.fn(),
-    flush: vi.fn(),
   } as any
 }
 
@@ -357,8 +350,10 @@ describe('IframeManager.sign timeout and empty-signature guard', () => {
   })
 
   it('rethrows non-timeout penpal errors as-is without poisoning the manager', async () => {
+    // CONNECTION_DESTROYED is mapped to a typed error elsewhere; use a code
+    // callRemote has no mapping for to prove the pass-through.
     const remote = {
-      sign: vi.fn().mockRejectedValue(new PenpalError('CONNECTION_DESTROYED', 'connection destroyed')),
+      sign: vi.fn().mockRejectedValue(new PenpalError('TRANSMISSION_FAILED', 'send failed')),
     }
     const manager = await makeConnectedManager(remote)
 
@@ -494,8 +489,10 @@ describe('IframeManager per-call RPC timeouts', () => {
       invoke: (m) => m.recover({ account: 'acc_1' }),
     },
     {
+      // Mutation budget: the child-side switchChain creates a new smart
+      // account and persists it — not a lookup (see RECOVERY_RPC_TIMEOUT_MS).
       method: 'switchChain',
-      timeout: 30_000,
+      timeout: 120_000,
       response: { version: '1', deviceID: 'dev_1', chainId: 137 },
       invoke: (m) => m.switchChain(137),
     },
@@ -577,15 +574,44 @@ describe('IframeManager per-call RPC timeouts', () => {
     expect(connectionDestroy).toHaveBeenCalledTimes(1)
   })
 
-  it('non-timeout RPC failures pass through untouched and do not poison the manager', async () => {
+  it('maps CONNECTION_DESTROYED to a typed error without poisoning (whoever destroyed the connection owns manager state)', async () => {
     const remote = {
       switchChain: vi.fn().mockRejectedValue(new PenpalError('CONNECTION_DESTROYED', 'connection destroyed')),
+    }
+    const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy(remote)
+
+    // A raw PenpalError is not part of the SDK's public error surface —
+    // consumers can't instanceof-check it.
+    await expect(manager.switchChain(1)).rejects.toBeInstanceOf(IframeConnectionDestroyedError)
+    expect(manager.hasFailed).toBe(false)
+    expect(connectionDestroy).not.toHaveBeenCalled()
+  })
+
+  it('other non-timeout RPC failures pass through untouched and do not poison the manager', async () => {
+    const remote = {
+      switchChain: vi.fn().mockRejectedValue(new PenpalError('TRANSMISSION_FAILED', 'send failed')),
     }
     const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy(remote)
 
     await expect(manager.switchChain(1)).rejects.toBeInstanceOf(PenpalError)
     expect(manager.hasFailed).toBe(false)
     expect(connectionDestroy).not.toHaveBeenCalled()
+  })
+
+  it('sign timeout carries the sign-specific copy in BOTH message and error_description', async () => {
+    // error_description is the field OpenfortError's docs tell consumers to
+    // display — it must not diverge from message (it did when the subclass
+    // patched this.message after super()).
+    const remote = {
+      sign: vi.fn().mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, 'timed out after 90000ms')),
+    }
+    const { manager } = await makeConnectedManagerWithDestroy(remote)
+
+    const caught = await manager.sign('0xdeadbeef').catch((e) => e)
+
+    expect(caught).toBeInstanceOf(IframeSignTimeoutError)
+    expect(caught.message).toMatch(/signing prompt may have been dismissed/i)
+    expect(caught.error_description).toBe(caught.message)
   })
 
   it('a sessionStorage SecurityError must not fail an operation that already succeeded', async () => {
@@ -676,6 +702,36 @@ describe('IframeManager connection-lost notifications', () => {
     expect(onConnectionLost).toHaveBeenCalledWith('handshake-timeout')
   })
 
+  it('suppresses the handshake-timeout notification when the caller retries the handshake itself', async () => {
+    // createSigner's first attempt passes this flag: a timeout it recovers
+    // from transparently must not surface as a connection-lost event.
+    const { manager, onConnectionLost } = makeManagerWithCallback(
+      Promise.reject(new PenpalError('CONNECTION_TIMEOUT', 'Connection timed out after 10000ms'))
+    )
+
+    await expect(manager.initialize({ suppressConnectionLostNotify: true })).rejects.toBeInstanceOf(
+      IframeHandshakeTimeoutError
+    )
+
+    expect(onConnectionLost).not.toHaveBeenCalled()
+  })
+
+  it('does NOT notify when the logout RPC times out (intentional teardown)', async () => {
+    // A frozen iframe during logout must still bound the flow (poison +
+    // teardown) but must not tell hosts the connection degraded — a host
+    // reacting (e.g. reloading a WebView) would race the logout itself.
+    const remote = {
+      logout: vi.fn().mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, 'timed out after 10000ms')),
+    }
+    const { manager, onConnectionLost } = makeManagerWithCallback(Promise.resolve(remote))
+    await manager.initialize()
+
+    await expect(manager.disconnect()).rejects.toBeInstanceOf(IframeRpcTimeoutError)
+
+    expect(manager.hasFailed).toBe(true)
+    expect(onConnectionLost).not.toHaveBeenCalled()
+  })
+
   it('notifies iframe-reloaded when the remote re-handshakes mid-session', async () => {
     const remote = { sign: vi.fn() }
     const { manager, onConnectionLost } = makeManagerWithCallback(Promise.resolve(remote))
@@ -705,5 +761,43 @@ describe('IframeManager connection-lost notifications', () => {
 
     await expect(manager.sign('0xdeadbeef')).rejects.toBeInstanceOf(IframeSignTimeoutError)
     expect(onConnectionLost).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('IframeManager remote-notification on teardown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Whether the remote is told about a teardown decides if a React Native
+  // WebView child (which cannot be reloaded) stays connectable: a penpal
+  // DESTROY makes it remove its message listeners permanently.
+
+  it('destroy() notifies the remote by default (deliberate browser teardown)', async () => {
+    const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy({ sign: vi.fn() })
+
+    manager.destroy()
+
+    expect(connectionDestroy).toHaveBeenCalledWith(true)
+  })
+
+  it('destroy({ notifyRemote: false }) tears down locally without a DESTROY message', async () => {
+    const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy({ sign: vi.fn() })
+
+    manager.destroy({ notifyRemote: false })
+
+    expect(connectionDestroy).toHaveBeenCalledWith(false)
+  })
+
+  it('an RPC-timeout teardown never notifies the remote (internal cleanup must keep the child connectable)', async () => {
+    const remote = {
+      sign: vi.fn().mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, 'timed out after 90000ms')),
+    }
+    const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy(remote)
+
+    await expect(manager.sign('0xdeadbeef')).rejects.toBeInstanceOf(IframeSignTimeoutError)
+
+    expect(connectionDestroy).toHaveBeenCalledTimes(1)
+    expect(connectionDestroy).toHaveBeenCalledWith(false)
   })
 })

--- a/sdk/src/wallets/iframeManager.test.ts
+++ b/sdk/src/wallets/iframeManager.test.ts
@@ -574,7 +574,7 @@ describe('IframeManager per-call RPC timeouts', () => {
     expect(connectionDestroy).toHaveBeenCalledTimes(1)
   })
 
-  it('maps CONNECTION_DESTROYED to a typed error without poisoning (whoever destroyed the connection owns manager state)', async () => {
+  it('maps CONNECTION_DESTROYED to a typed error and marks the manager for rebuild', async () => {
     const remote = {
       switchChain: vi.fn().mockRejectedValue(new PenpalError('CONNECTION_DESTROYED', 'connection destroyed')),
     }
@@ -583,7 +583,12 @@ describe('IframeManager per-call RPC timeouts', () => {
     // A raw PenpalError is not part of the SDK's public error surface —
     // consumers can't instanceof-check it.
     await expect(manager.switchChain(1)).rejects.toBeInstanceOf(IframeConnectionDestroyedError)
-    expect(manager.hasFailed).toBe(false)
+    // hasFailed must be set: for locally-initiated teardown it is a no-op
+    // (the initiator already set it), but a REMOTE-initiated destroy has no
+    // other path that marks the manager — without this it would stay
+    // isLoaded()-but-dead, failing every operation until logout.
+    expect(manager.hasFailed).toBe(true)
+    // Teardown itself belongs to whoever destroyed the connection.
     expect(connectionDestroy).not.toHaveBeenCalled()
   })
 

--- a/sdk/src/wallets/iframeManager.test.ts
+++ b/sdk/src/wallets/iframeManager.test.ts
@@ -3,6 +3,7 @@ import type { IStorage } from '../storage/istorage'
 import {
   IframeHandshakeTimeoutError,
   IframeManager,
+  IframeRpcTimeoutError,
   IframeSignEmptyResponseError,
   IframeSignTimeoutError,
   SessionEndedBeforeSetupError,
@@ -116,6 +117,19 @@ async function makeConnectedManager(remote: unknown) {
   const manager = new IframeManager(makeConfig(), makeAuthedStorage(), makeMessenger() as any)
   await manager.initialize()
   return manager
+}
+
+// Like makeConnectedManager, but also exposes the connection's destroy spy so
+// tests can assert the manager tears the connection down on RPC timeout.
+async function makeConnectedManagerWithDestroy(remote: unknown) {
+  const connectionDestroy = vi.fn()
+  vi.mocked(connect).mockReturnValue({
+    promise: Promise.resolve(remote),
+    destroy: connectionDestroy,
+  } as any)
+  const manager = new IframeManager(makeConfig(), makeAuthedStorage(), makeMessenger() as any)
+  await manager.initialize()
+  return { manager, connectionDestroy }
 }
 
 // Penpal's METHOD_CALL_TIMEOUT error code — what connectRemoteProxy rejects
@@ -440,5 +454,150 @@ describe('IframeManager.sign timeout and empty-signature guard', () => {
 
     await assertion
     expect(remote.sign).not.toHaveBeenCalled()
+  })
+})
+
+describe('IframeManager per-call RPC timeouts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Every remote RPC must hand penpal a CallOptions timeout — an unbounded
+  // RPC against a frozen/reloaded iframe hangs forever. Each case lists the
+  // method, its expected budget, a stub success response, and an invoker.
+  const cases: {
+    method: string
+    timeout: number
+    response: Record<string, unknown>
+    invoke: (manager: IframeManager) => Promise<unknown>
+  }[] = [
+    {
+      method: 'create',
+      timeout: 120_000,
+      response: { version: '1', account: 'acc_1', deviceID: 'dev_1', address: '0xabc' },
+      invoke: (m) => m.create({ accountType: 'smart' as any, chainType: 'EVM' as any }),
+    },
+    {
+      method: 'import',
+      timeout: 120_000,
+      response: { version: '1', account: 'acc_1', deviceID: 'dev_1', address: '0xabc' },
+      invoke: (m) => m.import({ privateKey: '0x01', accountType: 'smart' as any, chainType: 'EVM' as any }),
+    },
+    {
+      method: 'recover',
+      timeout: 120_000,
+      response: { version: '1', account: 'acc_1', deviceID: 'dev_1', address: '0xabc' },
+      invoke: (m) => m.recover({ account: 'acc_1' }),
+    },
+    {
+      method: 'switchChain',
+      timeout: 30_000,
+      response: { version: '1', deviceID: 'dev_1', chainId: 137 },
+      invoke: (m) => m.switchChain(137),
+    },
+    {
+      method: 'export',
+      timeout: 120_000,
+      response: { version: '1', key: '0xkey' },
+      invoke: (m) => m.export(),
+    },
+    {
+      method: 'setRecoveryMethod',
+      timeout: 120_000,
+      response: { version: '1' },
+      invoke: (m) => m.setRecoveryMethod('password' as any, 'pw'),
+    },
+    {
+      method: 'getCurrentDevice',
+      timeout: 30_000,
+      response: { version: '1', deviceID: 'dev_1' },
+      invoke: (m) => m.getCurrentDevice('player_1'),
+    },
+    {
+      method: 'logout',
+      timeout: 10_000,
+      response: {},
+      invoke: (m) => m.disconnect(),
+    },
+    {
+      method: 'updateAuthentication',
+      timeout: 30_000,
+      response: {},
+      invoke: (m) => m.updateAuthentication(),
+    },
+  ]
+
+  for (const { method, timeout, response, invoke } of cases) {
+    it(`bounds ${method}() with a ${timeout}ms per-call timeout`, async () => {
+      const remoteMethod = vi.fn().mockResolvedValue(response)
+      const remote = { [method]: remoteMethod }
+      const manager = await makeConnectedManager(remote)
+
+      await invoke(manager)
+
+      expect(remoteMethod).toHaveBeenCalledTimes(1)
+      const options = remoteMethod.mock.calls[0].at(-1)
+      expect(options?.timeout).toBe(timeout)
+    })
+
+    it(`maps a ${method}() METHOD_CALL_TIMEOUT to IframeRpcTimeoutError, poisons the manager, and tears down the connection`, async () => {
+      const remoteMethod = vi
+        .fn()
+        .mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, `timed out after ${timeout}ms`))
+      const remote = { [method]: remoteMethod }
+      const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy(remote)
+
+      await expect(invoke(manager)).rejects.toBeInstanceOf(IframeRpcTimeoutError)
+
+      // A frozen iframe must poison the manager so the parent rebuilds a fresh
+      // iframe + messenger on the next operation…
+      expect(manager.hasFailed).toBe(true)
+      // …and the dead connection must be destroyed so concurrent in-flight
+      // RPCs reject immediately instead of hanging out their own windows.
+      expect(connectionDestroy).toHaveBeenCalledTimes(1)
+      expect(manager.isLoaded()).toBe(false)
+    })
+  }
+
+  it('sign() timeout still surfaces the sign-specific error (which is an IframeRpcTimeoutError)', async () => {
+    const remote = {
+      sign: vi.fn().mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, 'timed out after 90000ms')),
+    }
+    const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy(remote)
+
+    const caught = await manager.sign('0xdeadbeef').catch((e) => e)
+
+    expect(caught).toBeInstanceOf(IframeSignTimeoutError)
+    expect(caught).toBeInstanceOf(IframeRpcTimeoutError)
+    expect(manager.hasFailed).toBe(true)
+    expect(connectionDestroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('non-timeout RPC failures pass through untouched and do not poison the manager', async () => {
+    const remote = {
+      switchChain: vi.fn().mockRejectedValue(new PenpalError('CONNECTION_DESTROYED', 'connection destroyed')),
+    }
+    const { manager, connectionDestroy } = await makeConnectedManagerWithDestroy(remote)
+
+    await expect(manager.switchChain(1)).rejects.toBeInstanceOf(PenpalError)
+    expect(manager.hasFailed).toBe(false)
+    expect(connectionDestroy).not.toHaveBeenCalled()
+  })
+
+  it('a sessionStorage SecurityError must not fail an operation that already succeeded', async () => {
+    const remote = { sign: vi.fn().mockResolvedValue({ signature: '0xsig', version: '1' }) }
+    const manager = await makeConnectedManager(remote)
+
+    // Storage-partitioned/sandboxed contexts throw on *access*, not just on
+    // quota — the diagnostic write must swallow it.
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError')
+    })
+
+    await expect(manager.sign('0xdeadbeef')).resolves.toBe('0xsig')
   })
 })

--- a/sdk/src/wallets/iframeManager.test.ts
+++ b/sdk/src/wallets/iframeManager.test.ts
@@ -601,3 +601,109 @@ describe('IframeManager per-call RPC timeouts', () => {
     await expect(manager.sign('0xdeadbeef')).resolves.toBe('0xsig')
   })
 })
+
+describe('IframeManager.handleError account preservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Drives handleError through a real RPC: the remote resolves with an
+  // iframe error-response payload ({ error: ... }), which sign() routes
+  // through handleError.
+  async function signWithErrorResponse(errorValue: string) {
+    const remote = { sign: vi.fn().mockResolvedValue({ uuid: 'u', error: errorValue }) }
+    const storage = makeAuthedStorage()
+    vi.mocked(connect).mockReturnValue({ promise: Promise.resolve(remote), destroy: vi.fn() } as any)
+    const manager = new IframeManager(makeConfig(), storage, makeMessenger() as any)
+    await manager.initialize()
+    const caught = await manager.sign('0xdeadbeef').catch((e) => e)
+    return { caught, storage }
+  }
+
+  it('does NOT clear the stored account on an unknown iframe error', async () => {
+    // An unknown error is just as likely a transient failure inside the
+    // iframe (failed storage read, network error mid-flow). Clearing the
+    // account on it forces the user through recovery with intact signer state.
+    const { caught, storage } = await signWithErrorResponse('Error: something transient went wrong')
+
+    expect((caught as Error).message).toMatch(/Unknown error/i)
+    expect(storage.remove).not.toHaveBeenCalled()
+  })
+
+  it('still clears the stored account on an explicit not-configured signal', async () => {
+    const { caught, storage } = await signWithErrorResponse('not-configured-error')
+
+    expect((caught as Error).message).toMatch(/not configured/i)
+    expect(storage.remove).toHaveBeenCalledWith('openfort.account')
+  })
+})
+
+describe('IframeManager connection-lost notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function makeManagerWithCallback(remotePromise: Promise<unknown>) {
+    const onConnectionLost = vi.fn()
+    vi.mocked(connect).mockReturnValue({ promise: remotePromise, destroy: vi.fn() } as any)
+    const manager = new IframeManager(makeConfig(), makeAuthedStorage(), makeMessenger() as any, {
+      onConnectionLost,
+    })
+    return { manager, onConnectionLost }
+  }
+
+  it('notifies rpc-timeout when a per-call timeout poisons the manager', async () => {
+    const remote = {
+      sign: vi.fn().mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, 'timed out after 90000ms')),
+    }
+    const { manager, onConnectionLost } = makeManagerWithCallback(Promise.resolve(remote))
+    await manager.initialize()
+
+    await expect(manager.sign('0xdeadbeef')).rejects.toBeInstanceOf(IframeSignTimeoutError)
+
+    expect(onConnectionLost).toHaveBeenCalledTimes(1)
+    expect(onConnectionLost).toHaveBeenCalledWith('rpc-timeout')
+  })
+
+  it('notifies handshake-timeout when the penpal handshake times out', async () => {
+    const { manager, onConnectionLost } = makeManagerWithCallback(
+      Promise.reject(new PenpalError('CONNECTION_TIMEOUT', 'Connection timed out after 10000ms'))
+    )
+
+    await expect(manager.initialize()).rejects.toBeInstanceOf(IframeHandshakeTimeoutError)
+
+    expect(onConnectionLost).toHaveBeenCalledTimes(1)
+    expect(onConnectionLost).toHaveBeenCalledWith('handshake-timeout')
+  })
+
+  it('notifies iframe-reloaded when the remote re-handshakes mid-session', async () => {
+    const remote = { sign: vi.fn() }
+    const { manager, onConnectionLost } = makeManagerWithCallback(Promise.resolve(remote))
+    await manager.initialize()
+
+    // connect() was handed an onRemoteReconnect hook — fire it the way
+    // shakeHands does when the embed page reloads and re-handshakes.
+    const connectOptions = vi.mocked(connect).mock.calls[0][0] as { onRemoteReconnect?: () => void }
+    connectOptions.onRemoteReconnect?.()
+
+    expect(onConnectionLost).toHaveBeenCalledTimes(1)
+    expect(onConnectionLost).toHaveBeenCalledWith('iframe-reloaded')
+  })
+
+  it('a throwing consumer callback must not change the surfaced error', async () => {
+    const remote = {
+      sign: vi.fn().mockRejectedValue(new PenpalError(METHOD_CALL_TIMEOUT, 'timed out after 90000ms')),
+    }
+    const onConnectionLost = vi.fn(() => {
+      throw new Error('consumer callback exploded')
+    })
+    vi.mocked(connect).mockReturnValue({ promise: Promise.resolve(remote), destroy: vi.fn() } as any)
+    const manager = new IframeManager(makeConfig(), makeAuthedStorage(), makeMessenger() as any, {
+      onConnectionLost,
+    })
+    await manager.initialize()
+
+    await expect(manager.sign('0xdeadbeef')).rejects.toBeInstanceOf(IframeSignTimeoutError)
+    expect(onConnectionLost).toHaveBeenCalledTimes(1)
+  })
+})

--- a/sdk/src/wallets/iframeManager.test.ts
+++ b/sdk/src/wallets/iframeManager.test.ts
@@ -633,7 +633,7 @@ describe('IframeManager per-call RPC timeouts', () => {
   })
 })
 
-describe('IframeManager.handleError account preservation', () => {
+describe('IframeManager.handleError account clearing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -651,17 +651,16 @@ describe('IframeManager.handleError account preservation', () => {
     return { caught, storage }
   }
 
-  it('does NOT clear the stored account on an unknown iframe error', async () => {
-    // An unknown error is just as likely a transient failure inside the
-    // iframe (failed storage read, network error mid-flow). Clearing the
-    // account on it forces the user through recovery with intact signer state.
-    const { caught, storage } = await signWithErrorResponse('Error: something transient went wrong')
+  it('clears the stored account on an unknown iframe error', async () => {
+    // Self-heal: an account the child keeps rejecting with an unrecognized
+    // error string must not stay READY and fail every operation until logout.
+    const { caught, storage } = await signWithErrorResponse('Error: something went wrong')
 
     expect((caught as Error).message).toMatch(/Unknown error/i)
-    expect(storage.remove).not.toHaveBeenCalled()
+    expect(storage.remove).toHaveBeenCalledWith('openfort.account')
   })
 
-  it('still clears the stored account on an explicit not-configured signal', async () => {
+  it('clears the stored account on an explicit not-configured signal', async () => {
     const { caught, storage } = await signWithErrorResponse('not-configured-error')
 
     expect((caught as Error).message).toMatch(/not configured/i)

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -663,16 +663,12 @@ export class IframeManager {
         throw method === 'sign' ? new IframeSignTimeoutError(timeoutMs) : new IframeRpcTimeoutError(method, timeoutMs)
       }
       if (error instanceof PenpalError && error.code === 'CONNECTION_DESTROYED') {
-        // The connection was torn down while this call was in flight — a
-        // concurrent RPC timed out, the consumer destroyed the manager, or
-        // the REMOTE side destroyed the connection (e.g. the embed page tore
-        // its end down). For the local cases hasFailed is already set and
-        // this assignment is a no-op; for a remote-initiated destroy nothing
-        // else marks the manager, and without it the manager stays
-        // isLoaded()-but-dead forever — every subsequent operation would
-        // throw this same error until logout. No notification here: the
-        // local cases already notified, and rebuilding on the next operation
-        // covers the remote case without prompting host reactions.
+        // Torn down mid-call. Local teardown (concurrent timeout / consumer
+        // destroy) already set hasFailed, so this is a no-op there. A
+        // remote-initiated destroy has no other path to mark the manager —
+        // without this it stays isLoaded()-but-dead, throwing forever until
+        // logout. No notify: the next operation rebuilds against a fresh
+        // manager, which covers the remote case.
         this.hasFailed = true
         throw new IframeConnectionDestroyedError(method)
       }

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -301,9 +301,9 @@ function recordIframeVersion(version: string | null | undefined): void {
  * `EmbeddedWalletConnectionLostPayload['reason']` — kept as a separate type so
  * this module doesn't depend on the public event types.
  */
-export type IframeConnectionLostReason = 'rpc-timeout' | 'handshake-timeout' | 'iframe-reloaded'
+type IframeConnectionLostReason = 'rpc-timeout' | 'handshake-timeout' | 'iframe-reloaded'
 
-export interface IframeManagerCallbacks {
+interface IframeManagerCallbacks {
   /**
    * Invoked when the connection degrades: an RPC or the handshake timed out,
    * or the embed page reloaded mid-session and re-handshaked. The parent

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -15,14 +15,7 @@ import type { AccountTypeEnum, ChainTypeEnum, EntropyResponse, RecoveryMethod } 
 import { randomUUID } from '../utils/crypto'
 import { debugLog } from '../utils/debug'
 import { ReactNativeMessenger } from './messaging'
-import {
-  CallOptions,
-  type Connection,
-  connect,
-  type Message,
-  type Messenger,
-  PenpalError,
-} from './messaging/browserMessenger'
+import { CallOptions, type Connection, connect, type Messenger, PenpalError } from './messaging/browserMessenger'
 import {
   type CreateRequest,
   type CreateResponse,
@@ -303,6 +296,23 @@ function recordIframeVersion(version: string | null | undefined): void {
   }
 }
 
+/**
+ * Reason passed to {@link IframeManagerCallbacks.onConnectionLost}. Mirrors
+ * `EmbeddedWalletConnectionLostPayload['reason']` — kept as a separate type so
+ * this module doesn't depend on the public event types.
+ */
+export type IframeConnectionLostReason = 'rpc-timeout' | 'handshake-timeout' | 'iframe-reloaded'
+
+export interface IframeManagerCallbacks {
+  /**
+   * Invoked when the connection degrades: an RPC or the handshake timed out,
+   * or the embed page reloaded mid-session and re-handshaked. The parent
+   * (EmbeddedWalletApi) surfaces this to consumers as an SDK event so hosts
+   * can react — e.g. a React Native app reloading its WebView.
+   */
+  onConnectionLost?: (reason: IframeConnectionLostReason) => void
+}
+
 export class IframeManager {
   private messenger: Messenger
 
@@ -314,6 +324,8 @@ export class IframeManager {
 
   private readonly sdkConfiguration: SDKConfiguration
 
+  private readonly callbacks: IframeManagerCallbacks
+
   private isInitialized = false
 
   private initializationPromise: Promise<void> | null = null
@@ -322,7 +334,12 @@ export class IframeManager {
 
   public hasFailed = false
 
-  constructor(configuration: SDKConfiguration, storage: IStorage, messenger: Messenger) {
+  constructor(
+    configuration: SDKConfiguration,
+    storage: IStorage,
+    messenger: Messenger,
+    callbacks: IframeManagerCallbacks = {}
+  ) {
     if (!configuration) {
       throw new ConfigurationError('Configuration is required for IframeManager')
     }
@@ -338,6 +355,19 @@ export class IframeManager {
     this.sdkConfiguration = configuration
     this.storage = storage
     this.messenger = messenger
+    this.callbacks = callbacks
+  }
+
+  /**
+   * Notify the parent of a connection-health transition. Consumer callbacks
+   * must never break connection handling, so failures are logged and dropped.
+   */
+  private notifyConnectionLost(reason: IframeConnectionLostReason): void {
+    try {
+      this.callbacks.onConnectionLost?.(reason)
+    } catch (callbackError) {
+      debugLog('onConnectionLost callback threw, swallowing:', callbackError)
+    }
   }
 
   /**
@@ -415,11 +445,12 @@ export class IframeManager {
     // of doInitialize, bail out before touching the messenger.
     this.assertAlive()
 
-    this.messenger.initialize({
-      validateReceivedMessage: (data: unknown): data is Message => !!(data && typeof data === 'object'),
-      log: debugLog,
-    })
-
+    // Note: the messenger is NOT initialized here. connect() initializes it
+    // with the proper penpal message validator. Initializing it first had two
+    // problems: the permissive validator installed here won (messenger
+    // initialization is first-wins), and ReactNativeMessenger flushed any
+    // buffered handshake messages before connect()/shakeHands had registered
+    // their handlers, dropping the iframe's first SYN.
     this.connection = connect<IframeAPI>({
       messenger: this.messenger,
       timeout: HANDSHAKE_TIMEOUT_MS,
@@ -432,6 +463,7 @@ export class IframeManager {
         // invisible and that failure looks like data corruption.
         debugLog('Iframe re-connected mid-session — embed page reloaded, signer state lost')
         sentry.captureException(new Error('Openfort iframe re-handshaked mid-session (embed page reloaded)'))
+        this.notifyConnectionLost('iframe-reloaded')
       },
     })
 
@@ -461,6 +493,7 @@ export class IframeManager {
       // "configure your origin" copy below, which is wrong for web embeds whose
       // origin is correctly configured.
       if (error instanceof PenpalError && error.code === 'CONNECTION_TIMEOUT') {
+        this.notifyConnectionLost('handshake-timeout')
         throw new IframeHandshakeTimeoutError(HANDSHAKE_TIMEOUT_MS, error)
       }
 
@@ -541,6 +574,7 @@ export class IframeManager {
       if (error instanceof PenpalError && error.code === 'METHOD_CALL_TIMEOUT') {
         this.hasFailed = true
         this.clearConnection()
+        this.notifyConnectionLost('rpc-timeout')
         throw method === 'sign' ? new IframeSignTimeoutError(timeoutMs) : new IframeRpcTimeoutError(method, timeoutMs)
       }
       throw error
@@ -568,7 +602,12 @@ export class IframeManager {
       } else if (error.error === OTP_REQUIRED_ERROR) {
         throw new OTPRequiredError()
       }
-      this.storage.remove(StorageKeys.ACCOUNT)
+      // Unknown errors must NOT clear the stored account. Only the explicit
+      // signals above prove the iframe evaluated this account and found it
+      // unconfigured/unrecoverable. An unknown error is just as likely a
+      // transient failure inside the iframe (a failed storage read, a network
+      // error mid-flow) — deleting the account on those forces the user
+      // through recovery even though their signer state is intact.
       throw new OpenfortError(OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR, `Unknown error: ${error.error}`)
     }
     throw error

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -11,7 +11,13 @@ import {
 } from '../core/errors/openfortError'
 import { sentry } from '../core/errors/sentry'
 import { type IStorage, StorageKeys } from '../storage/istorage'
-import type { AccountTypeEnum, ChainTypeEnum, EntropyResponse, RecoveryMethod } from '../types/types'
+import type {
+  AccountTypeEnum,
+  ChainTypeEnum,
+  EmbeddedWalletConnectionLostPayload,
+  EntropyResponse,
+  RecoveryMethod,
+} from '../types/types'
 import { randomUUID } from '../utils/crypto'
 import { debugLog } from '../utils/debug'
 import { ReactNativeMessenger } from './messaging'
@@ -162,10 +168,15 @@ export class OTPRequiredError extends OpenfortError {
  * an endless "Processing" spinner with no error.
  */
 export class IframeRpcTimeoutError extends SignerError {
-  constructor(method: string, timeoutMs: number) {
+  constructor(method: string, timeoutMs: number, description?: string) {
+    // The description must flow through the constructor chain: OpenfortError
+    // sets the readonly `error_description` (the field consumers are told to
+    // display) from it, so patching `this.message` afterwards would leave the
+    // two diverged.
     super(
       OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR,
-      `Iframe did not respond to ${method}() within ${timeoutMs}ms. The iframe may be frozen or unresponsive.`
+      description ??
+        `Iframe did not respond to ${method}() within ${timeoutMs}ms. The iframe may be frozen or unresponsive.`
     )
     this.name = 'IframeRpcTimeoutError'
     Object.setPrototypeOf(this, IframeRpcTimeoutError.prototype)
@@ -180,10 +191,30 @@ export class IframeRpcTimeoutError extends SignerError {
  */
 export class IframeSignTimeoutError extends IframeRpcTimeoutError {
   constructor(timeoutMs: number) {
-    super('sign', timeoutMs)
-    this.message = `Iframe signer did not respond within ${timeoutMs}ms. The signing prompt may have been dismissed or the iframe is unresponsive.`
+    super(
+      'sign',
+      timeoutMs,
+      `Iframe signer did not respond within ${timeoutMs}ms. The signing prompt may have been dismissed or the iframe is unresponsive.`
+    )
     this.name = 'IframeSignTimeoutError'
     Object.setPrototypeOf(this, IframeSignTimeoutError.prototype)
+  }
+}
+
+/**
+ * Thrown when an RPC was aborted because the iframe connection was torn down
+ * while the call was in flight — a concurrent RPC timed out (poisoning the
+ * manager) or the consumer destroyed it (e.g. logout). The operation did not
+ * complete on this side of the transport; the next operation rebuilds a fresh
+ * connection. Replaces penpal's internal CONNECTION_DESTROYED error, which is
+ * not part of the SDK's public error surface and cannot be instanceof-checked
+ * by consumers.
+ */
+export class IframeConnectionDestroyedError extends SignerError {
+  constructor(method: string) {
+    super(OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR, `Iframe connection was closed while ${method}() was in flight.`)
+    this.name = 'IframeConnectionDestroyedError'
+    Object.setPrototypeOf(this, IframeConnectionDestroyedError.prototype)
   }
 }
 
@@ -211,15 +242,22 @@ export class IframeSignEmptyResponseError extends SignerError {
 const DEFAULT_SIGN_TIMEOUT_MS = 90_000
 
 /**
- * Timeout for recovery-class RPCs (create/import/recover/setRecoveryMethod/
- * export). These run the longest iframe-side flows — Shield fetches plus
- * backend round-trips — so the budget is deliberately the most generous.
+ * Timeout for mutation-class RPCs (create/import/recover/setRecoveryMethod/
+ * export/switchChain). These run the longest iframe-side flows — Shield
+ * fetches plus backend round-trips (child-side switchChain creates a new
+ * smart account, not just a lookup) — so the budget is deliberately the most
+ * generous.
+ *
+ * Note: a timeout does NOT cancel the child-side operation. The embed has no
+ * timeout of its own, so it may still complete the mutation (and persist
+ * state) after the parent gave up; retrying create/recover after a timeout
+ * can therefore conflict with server-side state from the abandoned attempt.
  */
 const RECOVERY_RPC_TIMEOUT_MS = 120_000
 
 /**
- * Timeout for query-class RPCs (switchChain/getCurrentDevice/
- * updateAuthentication). These are single backend round-trips at most.
+ * Timeout for query-class RPCs (getCurrentDevice/updateAuthentication).
+ * These are single backend round-trips at most.
  */
 const QUERY_RPC_TIMEOUT_MS = 30_000
 
@@ -297,18 +335,19 @@ function recordIframeVersion(version: string | null | undefined): void {
 }
 
 /**
- * Reason passed to {@link IframeManagerCallbacks.onConnectionLost}. Mirrors
- * `EmbeddedWalletConnectionLostPayload['reason']` — kept as a separate type so
- * this module doesn't depend on the public event types.
+ * Reason passed to {@link IframeManagerCallbacks.onConnectionLost} — derived
+ * from the public event payload so the two unions cannot drift.
  */
-type IframeConnectionLostReason = 'rpc-timeout' | 'handshake-timeout' | 'iframe-reloaded'
+type IframeConnectionLostReason = EmbeddedWalletConnectionLostPayload['reason']
 
 interface IframeManagerCallbacks {
   /**
    * Invoked when the connection degrades: an RPC or the handshake timed out,
    * or the embed page reloaded mid-session and re-handshaked. The parent
-   * (EmbeddedWalletApi) surfaces this to consumers as an SDK event so hosts
-   * can react — e.g. a React Native app reloading its WebView.
+   * (EmbeddedWalletApi) surfaces this to consumers as an SDK event. Note the
+   * per-reason semantics on {@link OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST}:
+   * for 'iframe-reloaded' the transport has already recovered and hosts must
+   * NOT reload the embed in reaction.
    */
   onConnectionLost?: (reason: IframeConnectionLostReason) => void
 }
@@ -333,6 +372,23 @@ export class IframeManager {
   private isDestroyed = false
 
   public hasFailed = false
+
+  /**
+   * When true, a handshake CONNECTION_TIMEOUT does not fire the
+   * onConnectionLost callback. Set per-initialize() by callers that retry the
+   * handshake themselves (createSigner's first attempt): hosts must not react
+   * to a "loss" the SDK is about to recover from transparently. Applies to
+   * the doInitialize() started by that call; concurrent initialize() callers
+   * share the initiator's choice.
+   */
+  private suppressHandshakeLostNotify = false
+
+  /**
+   * Ensures the mid-session re-handshake Sentry report fires at most once per
+   * manager instance — a crash-looping embed re-handshakes repeatedly and
+   * would otherwise flood Sentry with identical events.
+   */
+  private hasReportedRemoteReconnect = false
 
   constructor(
     configuration: SDKConfiguration,
@@ -384,9 +440,13 @@ export class IframeManager {
   }
 
   /**
-   * Initialize the connection to the iframe/WebView
+   * Initialize the connection to the iframe/WebView.
+   *
+   * `suppressConnectionLostNotify` prevents a handshake timeout from firing
+   * the onConnectionLost callback — used by callers that retry the handshake
+   * themselves and only want the final failure surfaced to hosts.
    */
-  public async initialize(): Promise<void> {
+  public async initialize(options?: { suppressConnectionLostNotify?: boolean }): Promise<void> {
     // Refuse to resurrect a destroyed manager.
     this.assertAlive()
 
@@ -413,6 +473,7 @@ export class IframeManager {
     }
 
     // Start new initialization
+    this.suppressHandshakeLostNotify = options?.suppressConnectionLostNotify ?? false
     this.initializationPromise = this.doInitialize()
 
     try {
@@ -456,13 +517,18 @@ export class IframeManager {
       timeout: HANDSHAKE_TIMEOUT_MS,
       log: debugLog,
       onRemoteReconnect: () => {
-        // The embed page reloaded mid-session (browser memory pressure, crash,
-        // manual reload) and re-handshaked. The transport recovered, but the
-        // iframe's in-memory signer state is gone — the next operation will
-        // likely report NOT_CONFIGURED. Without this hook the reload is
-        // invisible and that failure looks like data corruption.
-        debugLog('Iframe re-connected mid-session — embed page reloaded, signer state lost')
-        sentry.captureException(new Error('Openfort iframe re-handshaked mid-session (embed page reloaded)'))
+        // The embed re-handshaked mid-session with a new participant id —
+        // usually the page reloaded (browser memory pressure, crash, manual
+        // reload), occasionally the child's own connect-retry after a dropped
+        // final ACK. The transport has already recovered; what may be gone is
+        // the iframe's in-memory signer state, so the next operation can
+        // report NOT_CONFIGURED. Without this hook the reload is invisible
+        // and that failure looks like data corruption.
+        debugLog('Iframe re-connected mid-session — embed page likely reloaded, in-memory signer state may be lost')
+        if (!this.hasReportedRemoteReconnect) {
+          this.hasReportedRemoteReconnect = true
+          sentry.captureException(new Error('Openfort iframe re-handshaked mid-session (embed page reloaded)'))
+        }
         this.notifyConnectionLost('iframe-reloaded')
       },
     })
@@ -493,7 +559,12 @@ export class IframeManager {
       // "configure your origin" copy below, which is wrong for web embeds whose
       // origin is correctly configured.
       if (error instanceof PenpalError && error.code === 'CONNECTION_TIMEOUT') {
-        this.notifyConnectionLost('handshake-timeout')
+        // Suppressed when the caller retries the handshake itself (see
+        // initialize) — the retry attempt initializes unsuppressed, so a
+        // final failure still notifies exactly once.
+        if (!this.suppressHandshakeLostNotify) {
+          this.notifyConnectionLost('handshake-timeout')
+        }
         throw new IframeHandshakeTimeoutError(HANDSHAKE_TIMEOUT_MS, error)
       }
 
@@ -520,11 +591,18 @@ export class IframeManager {
    * as destroyed. Used by `doInitialize()` on handshake failure so the
    * "configure your origin" hint is still reachable on retry. The public
    * `destroy()` method calls this in addition to setting `isDestroyed`.
+   *
+   * Internal cleanup never notifies the remote by default: sending a penpal
+   * DESTROY tells the child to remove its message listeners, and a React
+   * Native WebView child (which the SDK cannot reload) then becomes
+   * permanently unreachable — every rebuild handshake after an RPC timeout
+   * would dead-end. Only a deliberate, final teardown (`destroy()` in browser
+   * mode) notifies the remote.
    */
-  private clearConnection(): void {
+  private clearConnection(notifyRemote = false): void {
     if (this.connection) {
       try {
-        this.connection.destroy()
+        this.connection.destroy(notifyRemote)
       } catch (cleanupError) {
         // Teardown should never crash the consumer. If penpal's destroy
         // throws (it can — see the original OPENFORT-JS-HD report), log
@@ -574,8 +652,23 @@ export class IframeManager {
       if (error instanceof PenpalError && error.code === 'METHOD_CALL_TIMEOUT') {
         this.hasFailed = true
         this.clearConnection()
-        this.notifyConnectionLost('rpc-timeout')
+        // Logout is an intentional teardown: the timeout must still bound the
+        // logout flow (hasFailed + teardown above), but reporting it as a
+        // connection-health event would tell hosts the connection degraded in
+        // the middle of a deliberate logout, prompting reactions (e.g. a
+        // WebView reload) that race the teardown.
+        if (method !== 'logout') {
+          this.notifyConnectionLost('rpc-timeout')
+        }
         throw method === 'sign' ? new IframeSignTimeoutError(timeoutMs) : new IframeRpcTimeoutError(method, timeoutMs)
+      }
+      if (error instanceof PenpalError && error.code === 'CONNECTION_DESTROYED') {
+        // The connection was torn down while this call was in flight — a
+        // concurrent RPC timed out, or the consumer destroyed the manager.
+        // Whoever tore it down already handled manager state (no poisoning or
+        // notification here); this call just needs a typed error instead of
+        // leaking penpal's internal error class across the public API.
+        throw new IframeConnectionDestroyedError(method)
       }
       throw error
     }
@@ -608,6 +701,14 @@ export class IframeManager {
       // transient failure inside the iframe (a failed storage read, a network
       // error mid-flow) — deleting the account on those forces the user
       // through recovery even though their signer state is intact.
+      //
+      // Trade-off accepted here: the old clear-on-unknown was also the
+      // self-heal for a PERSISTENTLY broken account (child rejecting it with
+      // a non-standard error string every time) — that case now stays READY
+      // and keeps failing until the user logs out or explicitly re-recovers.
+      // If such a case surfaces, close it at the source: make the child emit
+      // a recognized signal (e.g. NOT_CONFIGURED) for every account-invalid
+      // condition it can detect, rather than re-widening this catch-all.
       throw new OpenfortError(OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR, `Unknown error: ${error.error}`)
     }
     throw error
@@ -873,7 +974,9 @@ export class IframeManager {
 
     const request = new SwitchChainRequest(randomUUID(), chainId, await this.buildRequestConfiguration())
 
-    const response = await this.callRemote('switchChain', QUERY_RPC_TIMEOUT_MS, (options) =>
+    // Mutation budget, not query: child-side switchChain creates a new smart
+    // account via the backend and persists it — see RECOVERY_RPC_TIMEOUT_MS.
+    const response = await this.callRemote('switchChain', RECOVERY_RPC_TIMEOUT_MS, (options) =>
       remote.switchChain(request, options)
     )
 
@@ -966,10 +1069,18 @@ export class IframeManager {
       return
     }
 
+    // Re-read after the await above: a concurrent RPC timeout can run
+    // clearConnection() (nulling this.remote) while we were reading storage —
+    // the narrowing from the top guard does not survive the await.
+    const remote = this.remote
+    if (!remote) {
+      debugLog('Connection was torn down during authentication update, skipping')
+      return
+    }
+
     const request = new UpdateAuthenticationRequest(randomUUID(), authentication.token)
 
     debugLog('Updating authentication in iframe with token')
-    const remote = this.remote
     const response = await this.callRemote('updateAuthentication', QUERY_RPC_TIMEOUT_MS, (options) =>
       remote.updateAuthentication(request, options)
     )
@@ -1019,7 +1130,7 @@ export class IframeManager {
     return this.isInitialized && this.remote !== undefined
   }
 
-  destroy(): void {
+  destroy(options?: { notifyRemote?: boolean }): void {
     // Idempotent: second call is a no-op. The first call marks the manager
     // dead immediately, so any in-flight `initialize()` sees `isDestroyed`
     // on its post-await checkpoint and rejects with
@@ -1031,6 +1142,11 @@ export class IframeManager {
     this.isDestroyed = true
     // Don't destroy messenger here - it's managed by EmbeddedWalletApi
     // and needs to be recreated fresh on retry.
-    this.clearConnection()
+    //
+    // notifyRemote defaults to true: a deliberate destroy in browser mode
+    // tells the disposable iframe child to release its resources. Pass false
+    // when the remote must stay connectable (React Native WebView child —
+    // see clearConnection).
+    this.clearConnection(options?.notifyRemote ?? true)
   }
 }

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -696,20 +696,12 @@ export class IframeManager {
       } else if (error.error === OTP_REQUIRED_ERROR) {
         throw new OTPRequiredError()
       }
-      // Unknown errors must NOT clear the stored account. Only the explicit
-      // signals above prove the iframe evaluated this account and found it
-      // unconfigured/unrecoverable. An unknown error is just as likely a
-      // transient failure inside the iframe (a failed storage read, a network
-      // error mid-flow) — deleting the account on those forces the user
-      // through recovery even though their signer state is intact.
-      //
-      // Trade-off accepted here: the old clear-on-unknown was also the
-      // self-heal for a PERSISTENTLY broken account (child rejecting it with
-      // a non-standard error string every time) — that case now stays READY
-      // and keeps failing until the user logs out or explicitly re-recovers.
-      // If such a case surfaces, close it at the source: make the child emit
-      // a recognized signal (e.g. NOT_CONFIGURED) for every account-invalid
-      // condition it can detect, rather than re-widening this catch-all.
+      // Unknown errors also clear the stored account: an account the child
+      // keeps rejecting with an unrecognized error string would otherwise
+      // stay READY and fail every operation until logout. The accepted cost
+      // is that a transient child-side failure surfacing as an unknown error
+      // sends the user back through recovery.
+      this.storage.remove(StorageKeys.ACCOUNT)
       throw new OpenfortError(OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR, `Unknown error: ${error.error}`)
     }
     throw error

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -98,16 +98,19 @@ export interface SignerRecoverRequest {
 }
 
 interface IframeAPI {
-  create(request: CreateRequest): Promise<CreateResponse>
-  import(request: ImportRequest): Promise<ImportResponse>
-  recover(request: RecoverRequest): Promise<RecoverResponse>
+  create(request: CreateRequest, options?: CallOptions): Promise<CreateResponse>
+  import(request: ImportRequest, options?: CallOptions): Promise<ImportResponse>
+  recover(request: RecoverRequest, options?: CallOptions): Promise<RecoverResponse>
   sign(request: SignRequest, options?: CallOptions): Promise<SignResponse>
-  switchChain(request: SwitchChainRequest): Promise<SwitchChainResponse>
-  updateAuthentication(request: UpdateAuthenticationRequest): Promise<UpdateAuthenticationResponse>
-  logout(request: any): Promise<LogoutResponse>
-  export(request: ExportPrivateKeyRequest): Promise<ExportPrivateKeyResponse>
-  setRecoveryMethod(request: SetRecoveryMethodRequest): Promise<SetRecoveryMethodResponse>
-  getCurrentDevice(request: GetCurrentDeviceRequest): Promise<GetCurrentDeviceResponse>
+  switchChain(request: SwitchChainRequest, options?: CallOptions): Promise<SwitchChainResponse>
+  updateAuthentication(
+    request: UpdateAuthenticationRequest,
+    options?: CallOptions
+  ): Promise<UpdateAuthenticationResponse>
+  logout(request: any, options?: CallOptions): Promise<LogoutResponse>
+  export(request: ExportPrivateKeyRequest, options?: CallOptions): Promise<ExportPrivateKeyResponse>
+  setRecoveryMethod(request: SetRecoveryMethodRequest, options?: CallOptions): Promise<SetRecoveryMethodResponse>
+  getCurrentDevice(request: GetCurrentDeviceRequest, options?: CallOptions): Promise<GetCurrentDeviceResponse>
   // Index signature to satisfy Iframe's Methods constraint
   [key: string]: (...args: any[]) => Promise<any>
 }
@@ -158,19 +161,34 @@ export class OTPRequiredError extends OpenfortError {
 }
 
 /**
- * Thrown when the iframe signer does not respond to a `sign` request within
- * the configured timeout window. The handshake itself succeeded — penpal is
- * connected — but `remote.sign()` never resolved. In practice this means the
- * passkey/biometry prompt was dismissed, the iframe is frozen, or a
- * postMessage was dropped. Without this timeout the promise hangs forever
- * and the caller sees an endless "Processing" spinner with no error.
+ * Thrown when the iframe does not respond to an RPC within the configured
+ * timeout window. The handshake itself succeeded — penpal is connected — but
+ * the remote method never resolved. In practice this means the iframe is
+ * frozen, was reloaded/removed mid-call, or a postMessage was dropped.
+ * Without a per-call timeout these promises hang forever and the caller sees
+ * an endless "Processing" spinner with no error.
  */
-export class IframeSignTimeoutError extends SignerError {
-  constructor(timeoutMs: number) {
+export class IframeRpcTimeoutError extends SignerError {
+  constructor(method: string, timeoutMs: number) {
     super(
       OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR,
-      `Iframe signer did not respond within ${timeoutMs}ms. The signing prompt may have been dismissed or the iframe is unresponsive.`
+      `Iframe did not respond to ${method}() within ${timeoutMs}ms. The iframe may be frozen or unresponsive.`
     )
+    this.name = 'IframeRpcTimeoutError'
+    Object.setPrototypeOf(this, IframeRpcTimeoutError.prototype)
+  }
+}
+
+/**
+ * Thrown when the iframe signer does not respond to a `sign` request within
+ * the configured timeout window. Specialization of `IframeRpcTimeoutError`:
+ * for sign the likely cause is a dismissed passkey/biometry prompt rather
+ * than a frozen iframe.
+ */
+export class IframeSignTimeoutError extends IframeRpcTimeoutError {
+  constructor(timeoutMs: number) {
+    super('sign', timeoutMs)
+    this.message = `Iframe signer did not respond within ${timeoutMs}ms. The signing prompt may have been dismissed or the iframe is unresponsive.`
     this.name = 'IframeSignTimeoutError'
     Object.setPrototypeOf(this, IframeSignTimeoutError.prototype)
   }
@@ -198,6 +216,25 @@ export class IframeSignEmptyResponseError extends SignerError {
  * passkey flows.
  */
 const DEFAULT_SIGN_TIMEOUT_MS = 90_000
+
+/**
+ * Timeout for recovery-class RPCs (create/import/recover/setRecoveryMethod/
+ * export). These run the longest iframe-side flows — Shield fetches plus
+ * backend round-trips — so the budget is deliberately the most generous.
+ */
+const RECOVERY_RPC_TIMEOUT_MS = 120_000
+
+/**
+ * Timeout for query-class RPCs (switchChain/getCurrentDevice/
+ * updateAuthentication). These are single backend round-trips at most.
+ */
+const QUERY_RPC_TIMEOUT_MS = 30_000
+
+/**
+ * Timeout for the logout RPC. Logout is best-effort cleanup — a frozen iframe
+ * must not stall the logout flow, so this budget is the tightest.
+ */
+const LOGOUT_RPC_TIMEOUT_MS = 10_000
 
 /**
  * Thrown when the consumer calls `destroy()` on an `IframeManager` before its
@@ -248,6 +285,23 @@ export class IframeHandshakeTimeoutError extends OpenfortError {
  * so `IframeHandshakeTimeoutError` reports the value actually used.
  */
 const HANDSHAKE_TIMEOUT_MS = 10_000
+
+/**
+ * Best-effort write of the iframe version diagnostic. `typeof sessionStorage`
+ * doesn't protect against environments where *accessing* storage throws
+ * (sandboxed documents, storage-partitioned or cookie-blocked contexts raise
+ * SecurityError). A diagnostic write must never fail an operation that
+ * already succeeded, so swallow any storage error.
+ */
+function recordIframeVersion(version: string | null | undefined): void {
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('iframe-version', version ?? 'undefined')
+    }
+  } catch (error) {
+    debugLog('Failed to record iframe-version diagnostic:', error)
+  }
+}
 
 export class IframeManager {
   private messenger: Messenger
@@ -370,6 +424,15 @@ export class IframeManager {
       messenger: this.messenger,
       timeout: HANDSHAKE_TIMEOUT_MS,
       log: debugLog,
+      onRemoteReconnect: () => {
+        // The embed page reloaded mid-session (browser memory pressure, crash,
+        // manual reload) and re-handshaked. The transport recovered, but the
+        // iframe's in-memory signer state is gone — the next operation will
+        // likely report NOT_CONFIGURED. Without this hook the reload is
+        // invisible and that failure looks like data corruption.
+        debugLog('Iframe re-connected mid-session — embed page reloaded, signer state lost')
+        sentry.captureException(new Error('Openfort iframe re-handshaked mid-session (embed page reloaded)'))
+      },
     })
 
     try {
@@ -452,6 +515,36 @@ export class IframeManager {
     }
 
     return this.remote
+  }
+
+  /**
+   * Invoke a remote RPC with a per-call timeout. Penpal bounds the RPC when
+   * handed a `CallOptions` timeout (see connectRemoteProxy); on expiry it
+   * rejects with a METHOD_CALL_TIMEOUT PenpalError, which we map to a typed
+   * `IframeRpcTimeoutError`. A timed-out RPC means the iframe is frozen or
+   * unresponsive, so in addition to failing this call we:
+   * - mark the manager failed so the parent rebuilds a fresh iframe +
+   *   messenger on the next operation (see `getIframeManager()` in
+   *   embeddedWallet), and
+   * - tear down the connection so concurrent in-flight RPCs reject with
+   *   CONNECTION_DESTROYED immediately instead of hanging out their own
+   *   windows, and the stale window listener/port are released.
+   */
+  private async callRemote<T>(
+    method: string,
+    timeoutMs: number,
+    invoke: (options: CallOptions) => Promise<T>
+  ): Promise<T> {
+    try {
+      return await invoke(new CallOptions({ timeout: timeoutMs }))
+    } catch (error) {
+      if (error instanceof PenpalError && error.code === 'METHOD_CALL_TIMEOUT') {
+        this.hasFailed = true
+        this.clearConnection()
+        throw method === 'sign' ? new IframeSignTimeoutError(timeoutMs) : new IframeRpcTimeoutError(method, timeoutMs)
+      }
+      throw error
+    }
   }
 
   private handleError(error: any): never {
@@ -570,15 +663,15 @@ export class IframeManager {
       nativeAppIdentifier: this.sdkConfiguration?.nativeAppIdentifier ?? null,
     }
 
-    const response = await remote.create(request)
+    const response = await this.callRemote('create', RECOVERY_RPC_TIMEOUT_MS, (options) =>
+      remote.create(request, options)
+    )
 
     if (isErrorResponse(response)) {
       this.handleError(response)
     }
 
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('iframe-version', response.version ?? 'undefined')
-    }
+    recordIframeVersion(response.version)
     return response
   }
 
@@ -619,15 +712,15 @@ export class IframeManager {
       nativeAppIdentifier: this.sdkConfiguration?.nativeAppIdentifier ?? null,
     }
 
-    const response = await remote.import(request)
+    const response = await this.callRemote('import', RECOVERY_RPC_TIMEOUT_MS, (options) =>
+      remote.import(request, options)
+    )
 
     if (isErrorResponse(response)) {
       this.handleError(response)
     }
 
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('iframe-version', response.version ?? 'undefined')
-    }
+    recordIframeVersion(response.version)
     return response
   }
 
@@ -668,15 +761,15 @@ export class IframeManager {
       nativeAppIdentifier: this.sdkConfiguration?.nativeAppIdentifier ?? null,
     }
 
-    const response = await remote.recover(request)
+    const response = await this.callRemote('recover', RECOVERY_RPC_TIMEOUT_MS, (options) =>
+      remote.recover(request, options)
+    )
 
     if (isErrorResponse(response)) {
       this.handleError(response)
     }
 
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('iframe-version', response.version ?? 'undefined')
-    }
+    recordIframeVersion(response.version)
     return response
   }
 
@@ -710,28 +803,14 @@ export class IframeManager {
     // `remote.sign()` has no inherent upper bound: the penpal handshake's 10s
     // timeout (see `connect()` in doInitialize) only covers connection setup,
     // so a dismissed passkey prompt or a frozen iframe would leave this await
-    // hanging forever and the caller stuck on "Processing". Penpal bounds the
-    // RPC itself when handed a per-call timeout (see connectRemoteProxy); on
-    // expiry it rejects with a METHOD_CALL_TIMEOUT PenpalError, which we map to
-    // a typed IframeSignTimeoutError. 90s is deliberately generous — a
-    // biometric prompt can legitimately take 30-60s, where the 10s connect
-    // timeout would false-positive.
-    let response: SignResponse
-    try {
-      response = await remote.sign(request, new CallOptions({ timeout: DEFAULT_SIGN_TIMEOUT_MS }))
-    } catch (error) {
-      if (error instanceof PenpalError && error.code === 'METHOD_CALL_TIMEOUT') {
-        // A timed-out RPC means the iframe is frozen/unresponsive. Leaving the
-        // manager `isInitialized` would hand the same dead connection to the
-        // next sign() (ensureConnection short-circuits on a live remote),
-        // hanging another full window. Mark it failed so the parent rebuilds a
-        // fresh iframe + messenger on the next operation (see
-        // `getIframeManager()`/`ensureSigner()` in embeddedWallet).
-        this.hasFailed = true
-        throw new IframeSignTimeoutError(DEFAULT_SIGN_TIMEOUT_MS)
-      }
-      throw error
-    }
+    // hanging forever and the caller stuck on "Processing". `callRemote` maps
+    // penpal's METHOD_CALL_TIMEOUT to a typed IframeSignTimeoutError and
+    // poisons the manager so the parent rebuilds a fresh iframe. 90s is
+    // deliberately generous — a biometric prompt can legitimately take
+    // 30-60s, where the 10s connect timeout would false-positive.
+    const response: SignResponse = await this.callRemote('sign', DEFAULT_SIGN_TIMEOUT_MS, (options) =>
+      remote.sign(request, options)
+    )
     debugLog('[iframe] response', response)
     if (isErrorResponse(response)) {
       this.handleError(response)
@@ -746,9 +825,7 @@ export class IframeManager {
       throw new IframeSignEmptyResponseError()
     }
 
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('iframe-version', response.version ?? 'undefined')
-    }
+    recordIframeVersion(response.version)
     return response.signature
   }
 
@@ -757,7 +834,9 @@ export class IframeManager {
 
     const request = new SwitchChainRequest(randomUUID(), chainId, await this.buildRequestConfiguration())
 
-    const response = await remote.switchChain(request)
+    const response = await this.callRemote('switchChain', QUERY_RPC_TIMEOUT_MS, (options) =>
+      remote.switchChain(request, options)
+    )
 
     if (isErrorResponse(response)) {
       this.handleError(response)
@@ -770,15 +849,15 @@ export class IframeManager {
 
     const request = new ExportPrivateKeyRequest(randomUUID(), await this.buildRequestConfiguration())
 
-    const response = await remote.export(request)
+    const response = await this.callRemote('export', RECOVERY_RPC_TIMEOUT_MS, (options) =>
+      remote.export(request, options)
+    )
 
     if (isErrorResponse(response)) {
       this.handleError(response)
     }
 
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('iframe-version', (response as ExportPrivateKeyResponse).version ?? 'undefined')
-    }
+    recordIframeVersion((response as ExportPrivateKeyResponse).version)
     return response.key
   }
 
@@ -802,15 +881,15 @@ export class IframeManager {
       passkeyId
     )
 
-    const response = await remote.setRecoveryMethod(request)
+    const response = await this.callRemote('setRecoveryMethod', RECOVERY_RPC_TIMEOUT_MS, (options) =>
+      remote.setRecoveryMethod(request, options)
+    )
 
     if (isErrorResponse(response)) {
       this.handleError(response)
     }
 
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('iframe-version', (response as SetRecoveryMethodResponse).version ?? 'undefined')
-    }
+    recordIframeVersion((response as SetRecoveryMethodResponse).version)
   }
 
   async getCurrentDevice(playerId: string): Promise<GetCurrentDeviceResponse | null> {
@@ -819,15 +898,15 @@ export class IframeManager {
     const request = new GetCurrentDeviceRequest(randomUUID(), playerId)
 
     try {
-      const response = await remote.getCurrentDevice(request)
+      const response = await this.callRemote('getCurrentDevice', QUERY_RPC_TIMEOUT_MS, (options) =>
+        remote.getCurrentDevice(request, options)
+      )
 
       if (isErrorResponse(response)) {
         this.handleError(response)
       }
 
-      if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('iframe-version', (response as GetCurrentDeviceResponse).version ?? 'undefined')
-      }
+      recordIframeVersion((response as GetCurrentDeviceResponse).version)
       return response
     } catch (e) {
       if (e instanceof NotConfiguredError) {
@@ -851,7 +930,10 @@ export class IframeManager {
     const request = new UpdateAuthenticationRequest(randomUUID(), authentication.token)
 
     debugLog('Updating authentication in iframe with token')
-    const response = await this.remote.updateAuthentication(request)
+    const remote = this.remote
+    const response = await this.callRemote('updateAuthentication', QUERY_RPC_TIMEOUT_MS, (options) =>
+      remote.updateAuthentication(request, options)
+    )
     if (isErrorResponse(response)) {
       this.handleError(response)
     }
@@ -860,7 +942,7 @@ export class IframeManager {
   async disconnect(): Promise<void> {
     const remote = await this.ensureConnection()
     const request = { uuid: randomUUID() }
-    await remote.logout(request)
+    await this.callRemote('logout', LOGOUT_RPC_TIMEOUT_MS, (options) => remote.logout(request, options))
   }
 
   /**

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -169,10 +169,10 @@ export class OTPRequiredError extends OpenfortError {
  */
 export class IframeRpcTimeoutError extends SignerError {
   constructor(method: string, timeoutMs: number, description?: string) {
-    // The description must flow through the constructor chain: OpenfortError
+    // Subclasses must pass their copy through this parameter: OpenfortError
     // sets the readonly `error_description` (the field consumers are told to
-    // display) from it, so patching `this.message` afterwards would leave the
-    // two diverged.
+    // display) from it, and patching `this.message` after super() would leave
+    // the two diverged.
     super(
       OPENFORT_AUTH_ERROR_CODES.INTERNAL_ERROR,
       description ??
@@ -344,10 +344,9 @@ interface IframeManagerCallbacks {
   /**
    * Invoked when the connection degrades: an RPC or the handshake timed out,
    * or the embed page reloaded mid-session and re-handshaked. The parent
-   * (EmbeddedWalletApi) surfaces this to consumers as an SDK event. Note the
-   * per-reason semantics on {@link OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST}:
-   * for 'iframe-reloaded' the transport has already recovered and hosts must
-   * NOT reload the embed in reaction.
+   * (EmbeddedWalletApi) surfaces this to consumers as an SDK event — see
+   * {@link OpenfortEvents.ON_EMBEDDED_WALLET_CONNECTION_LOST} for the
+   * per-reason semantics.
    */
   onConnectionLost?: (reason: IframeConnectionLostReason) => void
 }
@@ -506,12 +505,12 @@ export class IframeManager {
     // of doInitialize, bail out before touching the messenger.
     this.assertAlive()
 
-    // Note: the messenger is NOT initialized here. connect() initializes it
-    // with the proper penpal message validator. Initializing it first had two
-    // problems: the permissive validator installed here won (messenger
-    // initialization is first-wins), and ReactNativeMessenger flushed any
-    // buffered handshake messages before connect()/shakeHands had registered
-    // their handlers, dropping the iframe's first SYN.
+    // The messenger is NOT initialized here — connect() initializes it with
+    // the proper penpal message validator. Messenger initialization is
+    // first-wins, so initializing here would lock in a permissive validator
+    // and make ReactNativeMessenger flush buffered handshake messages before
+    // connect()/shakeHands register their handlers, dropping the iframe's
+    // first SYN.
     this.connection = connect<IframeAPI>({
       messenger: this.messenger,
       timeout: HANDSHAKE_TIMEOUT_MS,
@@ -663,12 +662,12 @@ export class IframeManager {
         throw method === 'sign' ? new IframeSignTimeoutError(timeoutMs) : new IframeRpcTimeoutError(method, timeoutMs)
       }
       if (error instanceof PenpalError && error.code === 'CONNECTION_DESTROYED') {
-        // Torn down mid-call. Local teardown (concurrent timeout / consumer
-        // destroy) already set hasFailed, so this is a no-op there. A
-        // remote-initiated destroy has no other path to mark the manager —
-        // without this it stays isLoaded()-but-dead, throwing forever until
-        // logout. No notify: the next operation rebuilds against a fresh
-        // manager, which covers the remote case.
+        // Torn down mid-call. For a REMOTE-initiated destroy this is the only
+        // path that marks the manager for rebuild — without it, it stays
+        // isLoaded()-but-dead, throwing forever until logout. Local teardowns
+        // already left the manager unusable (timeout sets hasFailed, consumer
+        // destroy sets isDestroyed), so this is harmless there. No notify:
+        // the next operation rebuilds against a fresh manager.
         this.hasFailed = true
         throw new IframeConnectionDestroyedError(method)
       }

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -664,10 +664,16 @@ export class IframeManager {
       }
       if (error instanceof PenpalError && error.code === 'CONNECTION_DESTROYED') {
         // The connection was torn down while this call was in flight — a
-        // concurrent RPC timed out, or the consumer destroyed the manager.
-        // Whoever tore it down already handled manager state (no poisoning or
-        // notification here); this call just needs a typed error instead of
-        // leaking penpal's internal error class across the public API.
+        // concurrent RPC timed out, the consumer destroyed the manager, or
+        // the REMOTE side destroyed the connection (e.g. the embed page tore
+        // its end down). For the local cases hasFailed is already set and
+        // this assignment is a no-op; for a remote-initiated destroy nothing
+        // else marks the manager, and without it the manager stays
+        // isLoaded()-but-dead forever — every subsequent operation would
+        // throw this same error until logout. No notification here: the
+        // local cases already notified, and rebuilding on the next operation
+        // covers the remote case without prompting host reactions.
+        this.hasFailed = true
         throw new IframeConnectionDestroyedError(method)
       }
       throw error

--- a/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
+++ b/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Message } from './browserMessenger'
+import { ReactNativeMessenger } from './ReactNativeMessenger'
+
+// One microtask tick — enough for the messenger's queueMicrotask flush,
+// which is scheduled before this await's continuation is queued.
+const runMicrotasks = () => Promise.resolve()
+
+function makeMessenger() {
+  return new ReactNativeMessenger({ postMessage: vi.fn() })
+}
+
+// The iframe's first handshake message, in the deprecated (v5) wire format
+// the WebView delivers. The messenger upgrades it to a modern SYN.
+const deprecatedSyn = { penpal: 'syn', participantId: 'participant-1' }
+
+describe('ReactNativeMessenger buffered-message flush ordering', () => {
+  it('delivers messages buffered before initialize() to handlers registered after initialize()', async () => {
+    const messenger = makeMessenger()
+
+    // Message arrives before anyone initialized the messenger — the exact
+    // shape of the production handshake, where the iframe's SYN triggers
+    // manager initialization.
+    messenger.handleMessage(deprecatedSyn)
+
+    // Mirror penpal's connect(): initialize, then register handlers, all in
+    // one synchronous block. A synchronous flush inside initialize() would
+    // fire before the handler exists and drop the SYN.
+    const received: unknown[] = []
+    messenger.initialize()
+    messenger.addMessageHandler((message) => received.push(message))
+
+    expect(received).toHaveLength(0)
+
+    await runMicrotasks()
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({ namespace: 'penpal', type: 'SYN', participantId: 'participant-1' })
+  })
+
+  it('preserves arrival order for messages received between initialize() and the flush', async () => {
+    const messenger = makeMessenger()
+
+    messenger.handleMessage(deprecatedSyn)
+
+    const received: { type?: string; penpal?: string }[] = []
+    messenger.initialize()
+    messenger.addMessageHandler((message) => received.push(message))
+
+    // Arrives while the flush is still pending — must queue behind the
+    // buffered SYN, not jump ahead of it.
+    messenger.handleMessage({ penpal: 'synAck', methodNames: ['sign'] })
+
+    await runMicrotasks()
+
+    expect(received.map((m) => m.type)).toEqual(['SYN', 'ACK1'])
+  })
+
+  it('processes messages synchronously once the flush has completed', async () => {
+    const messenger = makeMessenger()
+    const received: unknown[] = []
+
+    messenger.initialize()
+    messenger.addMessageHandler((message) => received.push(message))
+    await runMicrotasks()
+
+    messenger.handleMessage(deprecatedSyn)
+
+    expect(received).toHaveLength(1)
+  })
+
+  it('does not deliver buffered messages after destroy()', async () => {
+    const messenger = makeMessenger()
+    const received: unknown[] = []
+
+    messenger.handleMessage(deprecatedSyn)
+    messenger.initialize()
+    messenger.addMessageHandler((message) => received.push(message))
+
+    messenger.destroy()
+    await runMicrotasks()
+
+    expect(received).toHaveLength(0)
+  })
+
+  it('still validates flushed messages when a validator is provided', async () => {
+    const messenger = makeMessenger()
+    const received: unknown[] = []
+
+    messenger.handleMessage({ unrelated: true })
+    messenger.handleMessage(deprecatedSyn)
+
+    messenger.initialize({
+      validateReceivedMessage: (data: unknown): data is Message =>
+        !!data && typeof data === 'object' && (data as { namespace?: string }).namespace === 'penpal',
+    })
+    messenger.addMessageHandler((message) => received.push(message))
+
+    await runMicrotasks()
+
+    // The non-penpal message is filtered by the validator; the upgraded SYN
+    // passes.
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({ type: 'SYN' })
+  })
+})

--- a/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
+++ b/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
@@ -112,8 +112,8 @@ describe('ReactNativeMessenger buffered-message flush ordering', () => {
     const messenger = makeMessenger()
     const received: unknown[] = []
 
-    // `penpal: 'reply'` with a malformed body drives convertFromDeprecatedFormat
-    // into the reply branch, which reads properties a bad payload may lack.
+    // `penpal: 'call'` with a null methodName drives convertFromDeprecatedFormat
+    // into the call branch, where `methodName.split('.')` throws.
     messenger.handleMessage({ penpal: 'call', id: 1, methodName: null })
     messenger.handleMessage(deprecatedSyn)
 

--- a/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
+++ b/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
@@ -103,4 +103,49 @@ describe('ReactNativeMessenger buffered-message flush ordering', () => {
     expect(received).toHaveLength(1)
     expect(received[0]).toMatchObject({ type: 'SYN' })
   })
+
+  it('one bad buffered message must not drop the rest of the flush', async () => {
+    // Conversion/validation run before processMessage's guarded handler loop;
+    // an unguarded throw there would abort the forEach inside the microtask
+    // (unhandled rejection) and silently drop later handshake messages —
+    // stalling the connection until its 10s timeout.
+    const messenger = makeMessenger()
+    const received: unknown[] = []
+
+    // `penpal: 'reply'` with a malformed body drives convertFromDeprecatedFormat
+    // into the reply branch, which reads properties a bad payload may lack.
+    messenger.handleMessage({ penpal: 'call', id: 1, methodName: null })
+    messenger.handleMessage(deprecatedSyn)
+
+    messenger.initialize({
+      validateReceivedMessage: (data: unknown): data is Message =>
+        !!data && typeof data === 'object' && (data as { namespace?: string }).namespace === 'penpal',
+    })
+    messenger.addMessageHandler((message) => received.push(message))
+
+    await runMicrotasks()
+
+    // The malformed first message is skipped (methodName.split throws inside
+    // conversion); the buffered SYN behind it is still delivered.
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({ type: 'SYN' })
+  })
+
+  it('destroy() clears a scheduled flush so a reused messenger starts clean', async () => {
+    const messenger = makeMessenger()
+    const received: unknown[] = []
+
+    messenger.handleMessage(deprecatedSyn)
+    messenger.initialize()
+    messenger.addMessageHandler((message) => received.push(message))
+    messenger.destroy()
+
+    // Reuse after destroy: fresh buffer, fresh flush scheduling.
+    messenger.handleMessage(deprecatedSyn)
+    messenger.initialize()
+    messenger.addMessageHandler((message) => received.push(message))
+    await runMicrotasks()
+
+    expect(received).toHaveLength(1)
+  })
 })

--- a/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
+++ b/sdk/src/wallets/messaging/ReactNativeMessenger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { Message } from './browserMessenger'
+import type { Message } from './browserMessenger/types'
 import { ReactNativeMessenger } from './ReactNativeMessenger'
 
 // One microtask tick — enough for the messenger's queueMicrotask flush,

--- a/sdk/src/wallets/messaging/ReactNativeMessenger.ts
+++ b/sdk/src/wallets/messaging/ReactNativeMessenger.ts
@@ -81,7 +81,17 @@ export class ReactNativeMessenger implements Messenger {
       this.messageBuffer = []
       debugLog(`ReactNativeMessenger flushing ${bufferedMessages.length} buffered messages`)
       bufferedMessages.forEach((message) => {
-        this.processMessage(message)
+        // One malformed message must not abort the flush: the rest of the
+        // buffer can hold handshake messages (SYN/synAck) the connection
+        // depends on, and a throw here would also surface as an unhandled
+        // rejection inside the microtask instead of a connection error.
+        // processMessage guards its handler loop the same way, but its
+        // conversion/validation steps run before that guard.
+        try {
+          this.processMessage(message)
+        } catch (error) {
+          debugLog('ReactNativeMessenger: error processing buffered message, continuing flush:', error)
+        }
       })
     })
   }
@@ -377,6 +387,9 @@ export class ReactNativeMessenger implements Messenger {
     // Clear handlers and message buffer
     this.handlers.clear()
     this.messageBuffer = []
+    // A pending flush microtask bails on !isInitialized; clearing the flag
+    // here keeps handleMessage's buffering condition consistent too.
+    this.flushScheduled = false
 
     // Clear ID mappings
     this.stringToNumericId.clear()
@@ -396,6 +409,7 @@ export class ReactNativeMessenger implements Messenger {
     debugLog('ReactNativeMessenger reset for reuse')
     this.handlers.clear()
     this.messageBuffer = []
+    this.flushScheduled = false
     this.isInitialized = false
     this.hasBeenUsed = false
     // Reset ID mappings

--- a/sdk/src/wallets/messaging/ReactNativeMessenger.ts
+++ b/sdk/src/wallets/messaging/ReactNativeMessenger.ts
@@ -25,6 +25,8 @@ export class ReactNativeMessenger implements Messenger {
 
   private messageBuffer: any[] = []
 
+  private flushScheduled = false
+
   // ID mapping for string <-> number conversion
   private nextNumericId = 1
 
@@ -54,14 +56,33 @@ export class ReactNativeMessenger implements Messenger {
     this.isInitialized = true
     this.hasBeenUsed = true
 
-    debugLog(`ReactNativeMessenger initialized, processing ${this.messageBuffer.length} buffered messages`)
+    debugLog(`ReactNativeMessenger initialized, ${this.messageBuffer.length} buffered messages pending flush`)
 
-    // Process any messages that arrived before initialization
-    const bufferedMessages = [...this.messageBuffer]
-    this.messageBuffer = []
+    // Deliver buffered messages on a microtask rather than synchronously.
+    // initialize() is called from inside penpal's connect() BEFORE it (and
+    // shakeHands) register their message handlers in the same synchronous
+    // block — a synchronous flush here would route buffered handshake
+    // messages (e.g. the iframe's first SYN) to zero handlers and drop them.
+    this.scheduleBufferFlush()
+  }
 
-    bufferedMessages.forEach((message) => {
-      this.processMessage(message)
+  private scheduleBufferFlush(): void {
+    if (this.flushScheduled || this.messageBuffer.length === 0) {
+      return
+    }
+    this.flushScheduled = true
+    queueMicrotask(() => {
+      this.flushScheduled = false
+      // destroy()/reset() may have run before the microtask fired.
+      if (!this.isInitialized) {
+        return
+      }
+      const bufferedMessages = this.messageBuffer
+      this.messageBuffer = []
+      debugLog(`ReactNativeMessenger flushing ${bufferedMessages.length} buffered messages`)
+      bufferedMessages.forEach((message) => {
+        this.processMessage(message)
+      })
     })
   }
 
@@ -115,10 +136,13 @@ export class ReactNativeMessenger implements Messenger {
   handleMessage = (message: any): void => {
     debugLog('[HANDSHAKE DEBUG] ReactNativeMessenger.handleMessage called with:', message)
 
-    if (!this.isInitialized) {
+    // Buffer while uninitialized, and also while a flush is pending so a
+    // message arriving between initialize() and the flush microtask cannot be
+    // processed ahead of older buffered messages.
+    if (!this.isInitialized || this.flushScheduled) {
       const bufferSize = this.messageBuffer.length + 1
       debugLog(
-        '[HANDSHAKE DEBUG] ReactNativeMessenger: Message received but not initialized, ' +
+        '[HANDSHAKE DEBUG] ReactNativeMessenger: Message received before ready, ' +
           `buffering message (${bufferSize} total)`
       )
       this.messageBuffer.push(message)

--- a/sdk/src/wallets/messaging/browserMessenger/connect.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/connect.ts
@@ -31,6 +31,12 @@ type Options = {
    * logged when this is defined.
    */
   log?: Log
+  /**
+   * Called when the remote participant completes a new handshake after the
+   * connection was already established (the remote page reloaded and
+   * re-connected). See shakeHands for details.
+   */
+  onRemoteReconnect?: () => void
 }
 
 const usedMessengers = new WeakSet<Messenger>()
@@ -44,6 +50,7 @@ const connect = <TMethods extends Methods>({
   timeout,
   channel,
   log,
+  onRemoteReconnect,
 }: Options): Connection<TMethods> => {
   if (!messenger) {
     throw new PenpalError('INVALID_ARGUMENT', 'messenger must be defined')
@@ -99,6 +106,7 @@ const connect = <TMethods extends Methods>({
         timeout,
         channel,
         log,
+        onRemoteReconnect,
       })
       connectionDestroyedHandlers.push(destroy)
       return remoteProxy

--- a/sdk/src/wallets/messaging/browserMessenger/connect.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/connect.ts
@@ -120,8 +120,8 @@ const connect = <TMethods extends Methods>({
     promise,
     // Why we don't reject the connection promise when consumer calls destroy():
     // https://github.com/Aaronius/penpal/issues/51
-    destroy: () => {
-      destroyConnection(true)
+    destroy: (notifyRemote = true) => {
+      destroyConnection(notifyRemote)
     },
   }
 }

--- a/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.test.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.test.ts
@@ -1,16 +1,11 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import CallOptions from './CallOptions'
 import connectRemoteProxy from './connectRemoteProxy'
 import type { Message } from './types'
 
-// The shared test setup replaces `global.window` with a stub that omits timers
-// (src/__tests__/setup.ts). `connectRemoteProxy` deliberately calls
-// `window.setTimeout` (a real-browser global), so point it at the env timers.
-beforeAll(() => {
-  const w = globalThis as any
-  w.window.setTimeout = globalThis.setTimeout.bind(globalThis)
-  w.window.clearTimeout = globalThis.clearTimeout.bind(globalThis)
-})
+// connectRemoteProxy uses `globalThis.setTimeout` (it must work outside
+// browsers — React Native routes RPCs through this same proxy), so no window
+// timer stubbing is needed here.
 
 // A minimal in-memory Messenger: it records outgoing CALL messages and lets the
 // test inject the matching REPLY, standing in for the iframe side of penpal.

--- a/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.test.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.test.ts
@@ -3,10 +3,6 @@ import CallOptions from './CallOptions'
 import connectRemoteProxy from './connectRemoteProxy'
 import type { Message } from './types'
 
-// connectRemoteProxy uses `globalThis.setTimeout` (it must work outside
-// browsers — React Native routes RPCs through this same proxy), so no window
-// timer stubbing is needed here.
-
 // A minimal in-memory Messenger: it records outgoing CALL messages and lets the
 // test inject the matching REPLY, standing in for the iframe side of penpal.
 function makeFakeMessenger() {

--- a/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.ts
@@ -129,9 +129,7 @@ const connectRemoteProxy = <TMethods extends Methods>(
       // `globalThis.setTimeout`, NOT `window.setTimeout`: this proxy also runs
       // in React Native (the messenger only rewrites the wire format), where
       // `window` is an alias RN happens to provide but non-browser runtimes
-      // (workers, some embedded JS engines) do not. The explicit qualifier is
-      // kept so node's `Timeout` return type doesn't leak into the browser
-      // build during tests.
+      // (workers, some embedded JS engines) do not.
       const timeoutId =
         timeout !== undefined
           ? globalThis.setTimeout(() => {

--- a/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/connectRemoteProxy.ts
@@ -12,7 +12,7 @@ type ReplyHandler = {
   methodPath: MethodPath
   resolve: (value: unknown) => void
   reject: (reason: unknown) => void
-  timeoutId?: number
+  timeoutId?: ReturnType<typeof setTimeout>
 }
 
 const methodsToTreatAsNative = new Set(['apply', 'call', 'bind'])
@@ -126,18 +126,15 @@ const connectRemoteProxy = <TMethods extends Methods>(
     const argsWithoutOptions = lastArgIsOptions ? args.slice(0, -1) : args
 
     return new Promise((resolve, reject) => {
-      // We reference `window.setTimeout` instead of just `setTimeout`
-      // so that the TypeScript engine doesn't
-      // get confused when running tests. Something within
-      // Karma + @rollup/plugin-typescript leaks node types into source
-      // files when running tests. Node's setTimeout has a return type of
-      // Timeout rather than number, resulting in a build error when
-      // running tests if we don't disambiguate the browser setTimeout
-      // from node's setTimeout. There may be a better way to configure
-      // Karma + Rollup + Typescript to avoid node type leakage.
+      // `globalThis.setTimeout`, NOT `window.setTimeout`: this proxy also runs
+      // in React Native (the messenger only rewrites the wire format), where
+      // `window` is an alias RN happens to provide but non-browser runtimes
+      // (workers, some embedded JS engines) do not. The explicit qualifier is
+      // kept so node's `Timeout` return type doesn't leak into the browser
+      // build during tests.
       const timeoutId =
         timeout !== undefined
-          ? window.setTimeout(() => {
+          ? globalThis.setTimeout(() => {
               replyHandlers.delete(callId)
               reject(
                 new PenpalError(

--- a/sdk/src/wallets/messaging/browserMessenger/index.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/index.ts
@@ -6,7 +6,4 @@ export type { default as Messenger } from './messengers/Messenger'
 export { default as WindowMessenger } from './messengers/WindowMessenger'
 export { default as PenpalError } from './PenpalError'
 
-export type {
-  Connection,
-  Message,
-} from './types'
+export type { Connection } from './types'

--- a/sdk/src/wallets/messaging/browserMessenger/shakeHands.test.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/shakeHands.test.ts
@@ -89,6 +89,52 @@ describe('shakeHands remote re-connect detection', () => {
     connection.destroy()
   })
 
+  it('does not fire onRemoteReconnect for duplicate ACK1s from the SAME participant (RN deprecated-protocol shape)', async () => {
+    // The React Native child talks the deprecated wire format, which bypasses
+    // its SYN dedup and makes it the permanent handshake leader — so it
+    // answers EACH of our two SYNs with an ACK1. The second ACK1 lands after
+    // completion on virtually every healthy RN connection; treating it as a
+    // reconnect fired a false connection-lost event + Sentry error per connect.
+    const messenger = makeFakeMessenger()
+    const onRemoteReconnect = vi.fn()
+    const connection = connect({ messenger: messenger as any, timeout: 5000, onRemoteReconnect })
+
+    // '~' (0x7E) sorts above every hex digit, so the REMOTE is the handshake
+    // leader here (unlike completeHandshakeAs) and sends the ACK1s itself.
+    messenger.emit({ namespace: 'penpal', type: 'SYN', channel: undefined, participantId: '~~' })
+    messenger.emit({ namespace: 'penpal', type: 'ACK1', channel: undefined, methodPaths: [] })
+    await connection.promise
+
+    // The remote's answer to our second SYN — same participant, post-completion.
+    messenger.emit({ namespace: 'penpal', type: 'ACK1', channel: undefined, methodPaths: [] })
+
+    expect(onRemoteReconnect).not.toHaveBeenCalled()
+
+    // A genuinely NEW participant re-handshaking must still be detected.
+    messenger.emit({ namespace: 'penpal', type: 'SYN', channel: undefined, participantId: '~z' })
+    messenger.emit({ namespace: 'penpal', type: 'ACK1', channel: undefined, methodPaths: [] })
+
+    expect(onRemoteReconnect).toHaveBeenCalledTimes(1)
+
+    connection.destroy()
+  })
+
+  it('does not fire onRemoteReconnect for a duplicate ACK2 from the SAME participant', async () => {
+    const messenger = makeFakeMessenger()
+    const onRemoteReconnect = vi.fn()
+    const connection = connect({ messenger: messenger as any, timeout: 5000, onRemoteReconnect })
+
+    completeHandshakeAs(messenger, '!!')
+    await connection.promise
+
+    // A retransmitted ACK2 (dropped-message recovery) is not a reload.
+    messenger.emit({ namespace: 'penpal', type: 'ACK2', channel: undefined })
+
+    expect(onRemoteReconnect).not.toHaveBeenCalled()
+
+    connection.destroy()
+  })
+
   it('keeps working when onRemoteReconnect is not provided (reconnect stays supported)', async () => {
     const messenger = makeFakeMessenger()
     const connection = connect({ messenger: messenger as any, timeout: 5000 })

--- a/sdk/src/wallets/messaging/browserMessenger/shakeHands.test.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/shakeHands.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+import connect from './connect'
+import type { Message } from './types'
+
+// A minimal in-memory Messenger that records outgoing messages and lets the
+// test play the remote participant by injecting handshake messages.
+function makeFakeMessenger() {
+  const handlers = new Set<(message: Message) => void>()
+  const sent: any[] = []
+  return {
+    initialize: vi.fn(),
+    addMessageHandler: (cb: (message: Message) => void) => {
+      handlers.add(cb)
+    },
+    removeMessageHandler: (cb: (message: Message) => void) => {
+      handlers.delete(cb)
+    },
+    sendMessage: (message: any) => {
+      sent.push(message)
+    },
+    destroy: vi.fn(),
+    emit: (message: any) => {
+      for (const handler of [...handlers]) {
+        handler(message)
+      }
+    },
+    sent,
+  }
+}
+
+// Remote participant IDs are compared as strings to pick the handshake
+// leader. '!' (0x21) sorts below every hex digit, so an id of '!!' guarantees
+// the local participant (a random UUID) is the leader and will send ACK1 —
+// which makes the handshake fully drivable from the test: we inject SYN and
+// ACK2, the local side does the rest.
+const completeHandshakeAs = (messenger: ReturnType<typeof makeFakeMessenger>, remoteId: string) => {
+  messenger.emit({ namespace: 'penpal', type: 'SYN', channel: undefined, participantId: remoteId })
+  messenger.emit({ namespace: 'penpal', type: 'ACK2', channel: undefined })
+}
+
+describe('shakeHands remote re-connect detection', () => {
+  it('completes the handshake without firing onRemoteReconnect', async () => {
+    const messenger = makeFakeMessenger()
+    const onRemoteReconnect = vi.fn()
+    const connection = connect({ messenger: messenger as any, timeout: 5000, onRemoteReconnect })
+
+    completeHandshakeAs(messenger, '!!')
+
+    await expect(connection.promise).resolves.toBeDefined()
+    expect(onRemoteReconnect).not.toHaveBeenCalled()
+
+    // The local side must have sent SYN(s) and, as leader, an ACK1.
+    expect(messenger.sent.some((m) => m.type === 'SYN')).toBe(true)
+    expect(messenger.sent.some((m) => m.type === 'ACK1')).toBe(true)
+
+    connection.destroy()
+  })
+
+  it('fires onRemoteReconnect when the remote completes a NEW handshake after the connection was established', async () => {
+    const messenger = makeFakeMessenger()
+    const onRemoteReconnect = vi.fn()
+    const connection = connect({ messenger: messenger as any, timeout: 5000, onRemoteReconnect })
+
+    completeHandshakeAs(messenger, '!!')
+    await connection.promise
+
+    // The remote page reloads: fresh participant id, new SYN → re-handshake.
+    completeHandshakeAs(messenger, '!#')
+
+    expect(onRemoteReconnect).toHaveBeenCalledTimes(1)
+
+    connection.destroy()
+  })
+
+  it('does not fire onRemoteReconnect for duplicate SYNs from the SAME participant', async () => {
+    const messenger = makeFakeMessenger()
+    const onRemoteReconnect = vi.fn()
+    const connection = connect({ messenger: messenger as any, timeout: 5000, onRemoteReconnect })
+
+    completeHandshakeAs(messenger, '!!')
+    await connection.promise
+
+    // A duplicate SYN with the same id is part of the normal double-SYN
+    // protocol, not a reload — handleSynMessage ignores it entirely.
+    messenger.emit({ namespace: 'penpal', type: 'SYN', channel: undefined, participantId: '!!' })
+
+    expect(onRemoteReconnect).not.toHaveBeenCalled()
+
+    connection.destroy()
+  })
+
+  it('keeps working when onRemoteReconnect is not provided (reconnect stays supported)', async () => {
+    const messenger = makeFakeMessenger()
+    const connection = connect({ messenger: messenger as any, timeout: 5000 })
+
+    completeHandshakeAs(messenger, '!!')
+    await connection.promise
+
+    expect(() => completeHandshakeAs(messenger, '!#')).not.toThrow()
+
+    connection.destroy()
+  })
+})

--- a/sdk/src/wallets/messaging/browserMessenger/shakeHands.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/shakeHands.ts
@@ -16,6 +16,14 @@ type Options = {
   timeout: number | undefined
   channel: string | undefined
   log: Log | undefined
+  /**
+   * Called when the remote participant completes a NEW handshake after this
+   * connection was already established — i.e. the remote page reloaded and
+   * re-connected. The transport recovers transparently, but the remote's
+   * in-memory state is gone and any in-flight calls were dropped, so
+   * consumers usually want to log/report this and re-configure.
+   */
+  onRemoteReconnect: (() => void) | undefined
 }
 
 type HandshakeResult<TMethods extends Methods> = {
@@ -90,6 +98,7 @@ const shakeHands = <TMethods extends Methods>({
   timeout,
   channel,
   log,
+  onRemoteReconnect,
 }: Options): Promise<HandshakeResult<TMethods>> => {
   const participantId = randomUUID()
   let remoteParticipantId: string
@@ -115,8 +124,13 @@ const shakeHands = <TMethods extends Methods>({
 
   const connectCallHandlerAndMethodProxies = () => {
     if (isComplete) {
-      // If we get here, it means the remote is attempting to re-connect. While
-      // that's supported, we don't need to run the rest of this function again.
+      // If we get here, it means the remote re-connected (e.g. the remote page
+      // reloaded mid-session). The transport keeps working, but surface it to
+      // the consumer — the remote's in-memory state is gone and in-flight
+      // calls were dropped. We don't need to run the rest of this function
+      // again.
+      log?.('Remote participant re-connected after handshake completion')
+      onRemoteReconnect?.()
       return
     }
 

--- a/sdk/src/wallets/messaging/browserMessenger/shakeHands.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/shakeHands.ts
@@ -102,6 +102,11 @@ const shakeHands = <TMethods extends Methods>({
 }: Options): Promise<HandshakeResult<TMethods>> => {
   const participantId = randomUUID()
   let remoteParticipantId: string
+  // Participant the connection was completed (or last re-completed) with.
+  // Used to tell a genuine remote reload (NEW participant re-handshakes)
+  // apart from duplicate ACKs of the SAME participant, which the protocol
+  // produces routinely — see connectCallHandlerAndMethodProxies.
+  let completedRemoteParticipantId: string | undefined
   const destroyHandlers: (() => void)[] = []
   let isComplete = false
 
@@ -124,13 +129,23 @@ const shakeHands = <TMethods extends Methods>({
 
   const connectCallHandlerAndMethodProxies = () => {
     if (isComplete) {
-      // If we get here, it means the remote re-connected (e.g. the remote page
-      // reloaded mid-session). The transport keeps working, but surface it to
-      // the consumer — the remote's in-memory state is gone and in-flight
-      // calls were dropped. We don't need to run the rest of this function
-      // again.
-      log?.('Remote participant re-connected after handshake completion')
-      onRemoteReconnect?.()
+      // The remote finished another handshake after this connection was
+      // already established. Only a handshake from a NEW participant means
+      // the remote page actually reloaded (in-memory state gone, in-flight
+      // calls dropped). Duplicate ACKs from the SAME participant are protocol
+      // noise: the deprecated wire format bypasses the remote's SYN dedup, so
+      // a deprecated-protocol peer (e.g. talking to a React Native WebView)
+      // answers each of our two SYNs with its own ACK1, and the second one
+      // lands here on every healthy connection. A remote that only ever
+      // presents the shared deprecated participant id can therefore never be
+      // reload-detected — an accepted trade-off, since a false reload report
+      // (Sentry error + connection-lost event) is worse than a missed one.
+      // We don't need to run the rest of this function again either way.
+      if (remoteParticipantId !== completedRemoteParticipantId) {
+        completedRemoteParticipantId = remoteParticipantId
+        log?.('Remote participant re-connected after handshake completion')
+        onRemoteReconnect?.()
+      }
       return
     }
 
@@ -142,6 +157,7 @@ const shakeHands = <TMethods extends Methods>({
 
     clearTimeout(timeoutId)
     isComplete = true
+    completedRemoteParticipantId = remoteParticipantId
 
     resolve({
       remoteProxy,

--- a/sdk/src/wallets/messaging/browserMessenger/shakeHands.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/shakeHands.ts
@@ -140,7 +140,6 @@ const shakeHands = <TMethods extends Methods>({
       // presents the shared deprecated participant id can therefore never be
       // reload-detected — an accepted trade-off, since a false reload report
       // (Sentry error + connection-lost event) is worse than a missed one.
-      // We don't need to run the rest of this function again either way.
       if (remoteParticipantId !== completedRemoteParticipantId) {
         completedRemoteParticipantId = remoteParticipantId
         log?.('Remote participant re-connected after handshake completion')

--- a/sdk/src/wallets/messaging/browserMessenger/types.ts
+++ b/sdk/src/wallets/messaging/browserMessenger/types.ts
@@ -28,8 +28,14 @@ export type Connection<TMethods extends Methods = Methods> = {
   /**
    * A method that, when called, will disconnect any communication.
    * You may call this even before a connection has been established.
+   *
+   * Pass `false` to tear down locally WITHOUT sending a DESTROY message to
+   * the other participant. Use this when the remote must stay connectable —
+   * e.g. a React Native WebView child page that cannot be reloaded: a
+   * DESTROY makes it remove its message listeners permanently, so every
+   * later handshake against it times out.
    */
-  destroy: () => void
+  destroy: (notifyRemote?: boolean) => void
 }
 
 /**


### PR DESCRIPTION
- add per-call timeouts to all iframe RPCs (mutation-class 120s — create/import/recover/setRecoveryMethod/export/**switchChain** (child-side switchChain creates a new smart account, so it gets the mutation budget); query-class 30s; logout 10s; sign stays at 90s). Timeouts surface as a typed `IframeRpcTimeoutError`, mark the manager for recreation, and close the connection so other pending calls settle promptly — those settle as a typed `IframeConnectionDestroyedError` instead of a raw penpal error.
- tear down replaced IframeManagers (recreation path and logout) so their message listeners and ports are released deterministically. Teardown notification is explicit: internal cleanup and React Native logout never send a penpal DESTROY (a DESTROY permanently deafens a WebView child the SDK cannot reload); only a deliberate browser-mode logout notifies the disposable iframe child.
- ping() and browser-mode onMessage() no longer create an iframe element without connecting to it.
- logout only disconnects an existing live signer, is bounded by the logout timeout, and always completes its state cleanup. When no live connection exists but an account was configured (page reloaded since setup), logout does a best-effort, deadline-bounded flush of the embed's persisted signer state, and the hidden iframe element is removed either way. A logout-RPC timeout is not reported as a connection loss.
- createSigner() retries the handshake once with a fresh iframe after a handshake timeout — silently: the connection-lost event fires only after the retry is exhausted (exactly one event per failed operation, zero on transparent recovery).
- new `ON_EMBEDDED_WALLET_CONNECTION_LOST` event (`EmbeddedWalletConnectionLostPayload` exported) with per-reason semantics: `rpc-timeout` / `handshake-timeout` mean the connection is being rebuilt and hosts may react (e.g. reload a hidden WebView); `iframe-reloaded` means the transport already recovered — do NOT reload in reaction, but in-memory signer state may be gone. Mid-session reloads are detected via a new-participant re-handshake, so the deprecated wire protocol's duplicate ACKs (every healthy RN connect) no longer produce false reports; the Sentry report is once-guarded per manager.
- EvmProvider subscribes to the connection-lost event and drops its cached signer, so the EIP-1193 path (wagmi/viem) rebuilds after a poisoned manager instead of failing with 'Previous connection attempt failed' until logout.
- EmbeddedSigner.disconnect is best-effort so wallet_revokePermissions cannot fail on a frozen iframe; global event-emitter forwarding is derived from the OpenfortEvents enum (fixes new events silently missing from `openfortEvents`). Unknown iframe errors keep clearing the stored account (unchanged behavior — self-heal for accounts the child persistently rejects).
- clearer error when document.body is unavailable; iframe-version diagnostic writes are now best-effort; React Native buffered-message flush is microtask-based and survives a malformed message.

**Testing:** 271 unit tests; plus a new non-happy-path Playwright suite in auth-sample (`tests/connectionReliability.spec.ts`) driving slow, dead, and reloading embeds end-to-end against the local openfort-xyz/iframe#144 build — handshake retry, exactly-once event semantics, bounded logout against a dead embed, post-reload logout flush, and login/logout churn all green. Releases via changeset (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
