### PR TITLE
feat(funding): onramp client — session methods/quote + payment-method union

### DIFF
--- a/sdk/src/api/funding.test.ts
+++ b/sdk/src/api/funding.test.ts
@@ -151,6 +151,41 @@ describe('FundingApi', () => {
     }
   })
 
+  it('setPaymentMethod forwards the wallet-pay PII for a native apple_pay commit', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okJson({ id: 'fnd_1', clientSecret: 'cs_1', status: 'requires_payment_method' }))
+      .mockResolvedValueOnce(
+        okJson({
+          id: 'fnd_1',
+          status: 'waiting_payment',
+          paymentMethod: { type: 'onramp', method: 'apple_pay', angle: 'native', url: 'https://pay.coinbase.com/buy/1' },
+        })
+      )
+    const api = new FundingApi()
+    await api.sessions.create({ target: { chain: 'eip155:8453', currency: '0x0', address: '0x1' } })
+    await api.sessions.setPaymentMethod('fnd_1', {
+      paymentMethod: {
+        type: 'onramp',
+        method: 'apple_pay',
+        sourceAmount: '50.00',
+        sourceCurrency: 'USD',
+        email: 'buyer@example.com',
+        phoneNumber: '+14155550123',
+        phoneNumberVerifiedAt: '2026-07-07T12:00:00.000Z',
+        agreementAcceptedAt: '2026-07-07T12:01:00.000Z',
+      },
+    })
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body.paymentMethod).toMatchObject({
+      type: 'onramp',
+      method: 'apple_pay',
+      email: 'buyer@example.com',
+      phoneNumber: '+14155550123',
+      phoneNumberVerifiedAt: '2026-07-07T12:00:00.000Z',
+      agreementAcceptedAt: '2026-07-07T12:01:00.000Z',
+    })
+  })
+
   it('methods() GETs the session-scoped resolved rows with the remembered secret', async () => {
     fetchMock
       .mockResolvedValueOnce(okJson({ id: 'fnd_1', clientSecret: 'cs_1', status: 'requires_payment_method' }))

--- a/sdk/src/api/funding.test.ts
+++ b/sdk/src/api/funding.test.ts
@@ -127,4 +127,76 @@ describe('FundingApi', () => {
     expect(body.paymentMethod.type).toBe('cex')
     expect(body.paymentMethod.cex).toBe('binance')
   })
+
+  it('setPaymentMethod commits a fiat onramp and returns the checkout url', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okJson({ id: 'fnd_1', clientSecret: 'cs_1', status: 'requires_payment_method' }))
+      .mockResolvedValueOnce(
+        okJson({
+          id: 'fnd_1',
+          status: 'waiting_payment',
+          paymentMethod: { type: 'onramp', method: 'card', angle: 'iframe', url: 'https://crypto.link.com/s?x=1' },
+        })
+      )
+    const api = new FundingApi()
+    await api.sessions.create({ target: { chain: 'eip155:8453', currency: '0x0', address: '0x1' } })
+    const session = await api.sessions.setPaymentMethod('fnd_1', {
+      paymentMethod: { type: 'onramp', method: 'card', sourceAmount: '100.00', sourceCurrency: 'USD' },
+    })
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect(body.paymentMethod).toMatchObject({ type: 'onramp', method: 'card', sourceAmount: '100.00' })
+    expect(session.paymentMethod?.type).toBe('onramp')
+    if (session.paymentMethod?.type === 'onramp') {
+      expect(session.paymentMethod.url).toBe('https://crypto.link.com/s?x=1')
+    }
+  })
+
+  it('methods() GETs the session-scoped resolved rows with the remembered secret', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okJson({ id: 'fnd_1', clientSecret: 'cs_1', status: 'requires_payment_method' }))
+      .mockResolvedValueOnce(
+        okJson({
+          country: 'US',
+          methods: [{ method: 'card', provider: 'stripe', angle: 'iframe', label: 'Card' }],
+        })
+      )
+    const api = new FundingApi()
+    await api.sessions.create({ target: { chain: 'eip155:8453', currency: '0x0', address: '0x1' } })
+    const resolved = await api.sessions.methods('fnd_1', { country: 'US' })
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.test/v2/funding/sessions/fnd_1/methods?clientSecret=cs_1&country=US'
+    )
+    expect(resolved.country).toBe('US')
+    expect(resolved.methods[0]?.label).toBe('Card')
+  })
+
+  it('quote() POSTs the fiat route and returns the priced quote', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okJson({
+        provider: 'stripe',
+        sourceAmount: '100.00',
+        sourceCurrency: 'USD',
+        destinationAmount: '98.20',
+        destinationCurrency: 'USDC',
+        destinationNetwork: 'base',
+        fees: [{ type: 'transaction_fee', amount: '1.80', currency: 'USD' }],
+        exchangeRate: '1.018330',
+      })
+    )
+    const quote = await new FundingApi().sessions.quote('fnd_1', {
+      clientSecret: 'cs_1',
+      method: 'card',
+      sourceAmount: '100.00',
+      sourceCurrency: 'USD',
+    })
+    const [calledUrl, init] = fetchMock.mock.calls[0]
+    expect(calledUrl).toBe('https://api.test/v2/funding/sessions/fnd_1/quotes')
+    expect(JSON.parse(init.body)).toMatchObject({
+      clientSecret: 'cs_1',
+      method: 'card',
+      sourceAmount: '100.00',
+      sourceCurrency: 'USD',
+    })
+    expect(quote.destinationAmount).toBe('98.20')
+  })
 })

--- a/sdk/src/api/funding.ts
+++ b/sdk/src/api/funding.ts
@@ -78,6 +78,36 @@ export type FundingPaymentMethodInput =
       country?: string
       /** URL the provider redirects back to after checkout. */
       redirectUrl?: string
+      /**
+       * Origin-chain refund address for an auto-bridged (chained) route — where
+       * the onramped intermediate is refunded if the bridge to the target
+       * bounces. Only needed when the route chains cross-VM (e.g. an EVM
+       * intermediate to a Solana target); same-VM chains refund automatically.
+       */
+      refundTo?: string
+      /**
+       * OTP-verified buyer email — REQUIRED for `apple_pay`/`google_pay`, which
+       * mint a Coinbase native order that needs partner-verified PII. Verify it
+       * via Openfort's own email OTP first. Ignored for `card`/`bank_transfer`.
+       */
+      email?: string
+      /**
+       * OTP-verified US mobile in E.164 — REQUIRED for `apple_pay`/`google_pay`.
+       * Verify it via Openfort's own phone OTP first. Ignored for
+       * `card`/`bank_transfer`.
+       * @example "+14155550123"
+       */
+      phoneNumber?: string
+      /**
+       * ISO-8601 time the phone OTP was verified. REQUIRED for
+       * `apple_pay`/`google_pay`; must be within Coinbase's 60-day re-verify window.
+       */
+      phoneNumberVerifiedAt?: string
+      /**
+       * ISO-8601 time the buyer accepted Coinbase's Guest Checkout terms (shown at
+       * the amount step). REQUIRED for `apple_pay`/`google_pay`.
+       */
+      agreementAcceptedAt?: string
     }
 
 export type FundingSessionStatus =

--- a/sdk/src/api/funding.ts
+++ b/sdk/src/api/funding.ts
@@ -136,6 +136,11 @@ export interface FundingOnrampPaymentMethod {
   angle: OnrampAngle
   /** Hosted checkout URL to open, or null. */
   url: string | null
+  /**
+   * Provider session secret for embeddable checkouts (e.g. Stripe's embedded
+   * onramp element mounts with it), or null when the provider has none.
+   */
+  providerClientSecret: string | null
   fees: FundingFee[]
   minAmount: string | null
 }

--- a/sdk/src/api/funding.ts
+++ b/sdk/src/api/funding.ts
@@ -1,19 +1,6 @@
 import { SDKConfiguration } from '../core/config/config'
 import { ConfigurationError, RequestError } from '../core/errors/openfortError'
 
-/**
- * Funding (cross-chain wallet deposit) resource.
- *
- * Wraps the API's `/v2/funding` session endpoints: create a session for a
- * destination, set a single payment method (a source route) to mint a Relay
- * deposit address, then poll until terminal. Sessions are guarded by a
- * per-session `clientSecret` and authenticated with the project publishable key.
- *
- * NOTE: This thin wrapper calls the backend directly. Once the API's funding
- * endpoints are part of the published OpenAPI spec, this can move onto the
- * generated `BackendApiClients.fundingApi` like the other resources.
- */
-
 /** Where the funded crypto should land (CAIP-2 chain + token + wallet). */
 export interface FundingTarget {
   chain: string
@@ -56,11 +43,20 @@ interface FundingPaymentMethodBase {
   refundTo?: string
 }
 
+/** Fiat web2 funding methods. The rail the user sees, never the provider. */
+export type OnrampMethodId = 'apple_pay' | 'google_pay' | 'card' | 'bank_transfer'
+
+/** How a resolved onramp executes: open a hosted `url`, or an in-page provider SDK. */
+export type OnrampAngle = 'iframe' | 'native'
+
 /**
- * The source route the user commits to. `evm` / `solana` are self-custody
+ * The payment method the user commits to. `evm` / `solana` are self-custody
  * transfers; `cex` is a guided withdrawal from a centralized exchange — the same
  * deposit address, plus withdrawal guidance (network, minimum, memo) and no
- * wallet deeplinks (exchanges don't expose them).
+ * wallet deeplinks (exchanges don't expose them). `onramp` is a fiat purchase —
+ * the server resolves the provider (buyer region + destination + project config)
+ * and returns a checkout `url`; settlement advances the same session lifecycle
+ * via the provider's webhook.
  */
 export type FundingPaymentMethodInput =
   | (FundingPaymentMethodBase & { type: 'evm' })
@@ -70,6 +66,19 @@ export type FundingPaymentMethodInput =
       /** Exchange id, e.g. "binance" | "coinbase". */
       cex: string
     })
+  | {
+      type: 'onramp'
+      /** The fiat method the user picked (from `sessions.methods()`). */
+      method: OnrampMethodId
+      /** Fiat amount to prefill in the checkout, human units (e.g. "100.00"). */
+      sourceAmount?: string
+      /** ISO-4217 fiat currency for `sourceAmount`. */
+      sourceCurrency?: string
+      /** Buyer-country override (ISO-3166 alpha-2); defaults to the request IP. */
+      country?: string
+      /** URL the provider redirects back to after checkout. */
+      redirectUrl?: string
+    }
 
 export type FundingSessionStatus =
   | 'requires_payment_method'
@@ -103,8 +112,9 @@ export interface FundingCexGuidance {
   requiresMemo: boolean
 }
 
-export interface FundingPaymentMethod {
-  type: string
+/** A committed crypto source route: deposit address, QR uri, deeplinks. */
+export interface FundingCryptoPaymentMethod {
+  type: 'evm' | 'solana' | 'cex'
   source: FundingSource
   receiverAddress: string
   addressUri: string
@@ -114,6 +124,23 @@ export interface FundingPaymentMethod {
   fees: FundingFee[]
   minAmount: string | null
 }
+
+/**
+ * A committed fiat onramp. The executing provider is resolved server-side and
+ * never part of the response — open `url` (iframe angle) and track the session
+ * status; settlement is webhook-driven.
+ */
+export interface FundingOnrampPaymentMethod {
+  type: 'onramp'
+  method: OnrampMethodId
+  angle: OnrampAngle
+  /** Hosted checkout URL to open, or null. */
+  url: string | null
+  fees: FundingFee[]
+  minAmount: string | null
+}
+
+export type FundingPaymentMethod = FundingCryptoPaymentMethod | FundingOnrampPaymentMethod
 
 export interface FundingSession {
   id: string
@@ -168,6 +195,48 @@ export interface FundingChain {
   logo: string | null
   vmType: string
   currencies: FundingCurrency[]
+}
+
+/**
+ * One fiat method row to render. The provider is included for telemetry only —
+ * it is not shown to the user and never chosen by the client.
+ */
+export interface ResolvedFundingMethod {
+  method: OnrampMethodId
+  provider: string
+  angle: OnrampAngle
+  /** Server-resolved display label; bank_transfer shows the regional rail. */
+  label: string
+  /** The regional bank rail behind `label`, for bank_transfer. */
+  rail?: 'ach' | 'sepa' | 'interac'
+  /** Gate the row on device capability client-side (e.g. Apple Pay on Safari). */
+  requiresDeviceCheck?: boolean
+}
+
+/** The fiat methods resolved for a session's destination and the buyer's region. */
+export interface ResolvedFundingMethods {
+  /** Resolved ISO-3166 alpha-2 country, or null for rest-of-world. */
+  country: string | null
+  methods: ResolvedFundingMethod[]
+}
+
+/** A single fee leg of an onramp quote, in the source (fiat) currency. */
+export interface OnrampQuoteFee {
+  type: string
+  amount: string
+  currency: string
+}
+
+/** A priced onramp route: what the entered fiat buys after fees. */
+export interface OnrampQuote {
+  provider: string
+  sourceAmount: string
+  sourceCurrency: string
+  destinationAmount: string
+  destinationCurrency: string
+  destinationNetwork: string
+  fees: OnrampQuoteFee[]
+  exchangeRate: string
 }
 
 /** Hard ceiling per funding request so a stalled backend can't hang the app. */
@@ -250,6 +319,52 @@ export class FundingApi {
         `/v2/funding/sessions/${sessionId}?clientSecret=${encodeURIComponent(secret)}`
       )
     },
+
+    /**
+     * Resolve the fiat methods available for this session's destination and the
+     * buyer's region (server-detected from the request IP, or an explicit
+     * `country` override). Render one row per method — the provider is already
+     * chosen server-side. Commit one via `setPaymentMethod({ type: 'onramp', method })`.
+     */
+    methods: async (
+      sessionId: string,
+      params?: { clientSecret?: string; country?: string }
+    ): Promise<ResolvedFundingMethods> => {
+      const secret = this.resolveSecret(sessionId, params?.clientSecret)
+      const query = new URLSearchParams({ clientSecret: secret })
+      if (params?.country) {
+        query.set('country', params.country)
+      }
+      return this.request<ResolvedFundingMethods>(`/v2/funding/sessions/${sessionId}/methods?${query.toString()}`)
+    },
+
+    /**
+     * Price a fiat route before committing it. The provider is resolved exactly
+     * as `setPaymentMethod` would resolve it, so the quote matches the checkout
+     * the user will get.
+     */
+    quote: async (
+      sessionId: string,
+      params: {
+        method: OnrampMethodId
+        /** Fiat amount in human units, e.g. "100.00". */
+        sourceAmount: string
+        /** ISO-4217 fiat currency, e.g. "USD". */
+        sourceCurrency: string
+        country?: string
+        clientSecret?: string
+      }
+    ): Promise<OnrampQuote> =>
+      this.request<OnrampQuote>(`/v2/funding/sessions/${sessionId}/quotes`, {
+        method: 'POST',
+        body: JSON.stringify({
+          clientSecret: this.resolveSecret(sessionId, params.clientSecret),
+          method: params.method,
+          sourceAmount: params.sourceAmount,
+          sourceCurrency: params.sourceCurrency,
+          country: params.country,
+        }),
+      }),
 
     /**
      * Poll a session until it reaches a terminal status (`succeeded`, `bounced`,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,8 +12,10 @@ export {
   FundingApi,
   type FundingCexGuidance,
   type FundingChain,
+  type FundingCryptoPaymentMethod,
   type FundingCurrency,
   type FundingFee,
+  type FundingOnrampPaymentMethod,
   type FundingPaymentMethod,
   type FundingPaymentMethodInput,
   type FundingSession,
@@ -21,7 +23,13 @@ export {
   type FundingSource,
   type FundingTarget,
   type FundingWalletDeeplink,
+  type OnrampAngle,
+  type OnrampMethodId,
+  type OnrampQuote,
+  type OnrampQuoteFee,
   type PayLinkParams,
+  type ResolvedFundingMethod,
+  type ResolvedFundingMethods,
 } from './api/funding'
 export { ProxyApi } from './api/proxy'
 export { UserApi } from './api/user'


### PR DESCRIPTION
Adds the fiat onramp surface to `openfort.funding`, on top of the crypto/CEX session client already in main.

- `sessions.methods(id)` — resolve the region-routed fiat methods for a session's destination (provider is hidden; the server decides).
- `sessions.quote(id)` — price a fiat route with the same provider a commit would resolve.
- `setPaymentMethod` accepts `{ type: 'onramp', method }`; `FundingPaymentMethod` becomes a `crypto | onramp` union.
- `providerClientSecret` on the onramp payment method, for providers with an embeddable checkout (Stripe's embedded element).

12 unit tests. Pairs with the api onramp endpoints (openfort-xyz/api#1086) that these call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)