### PR TITLE
fix(siwe): send chainId on SIWE login nonce and verify

### DIFF
--- a/.changeset/siwe-send-chainid.md
+++ b/.changeset/siwe-send-chainid.md
@@ -1,0 +1,5 @@
+---
+"@openfort/openfort-js": patch
+---
+
+Send `chainId` on the SIWE login flow. `auth.initSiwe` and `auth.loginWithSiwe` now accept an optional `chainId`, forwarded to the `/siwe/nonce` and `/siwe/verify` requests. Without it the backend defaults the request chain ID to `1`, which no longer matches the chain ID embedded in the signed SIWE message and fails verification with `UNAUTHORIZED_SIWE_MESSAGE_MISMATCH`.

--- a/sdk/src/api/auth.ts
+++ b/sdk/src/api/auth.ts
@@ -351,9 +351,9 @@ export class AuthApi {
     return await this.authManager.unlinkOAuth(provider, auth)
   }
 
-  async initSiwe({ address }: { address: string }): Promise<SIWEInitResponse> {
+  async initSiwe({ address, chainId }: { address: string; chainId?: number }): Promise<SIWEInitResponse> {
     await this.ensureInitialized()
-    return await this.authManager.initSIWE(address)
+    return await this.authManager.initSIWE(address, chainId)
   }
 
   async initLinkSiwe({ address }: { address: string }): Promise<SIWEInitResponse> {
@@ -371,12 +371,14 @@ export class AuthApi {
     walletClientType,
     connectorType,
     address,
+    chainId,
   }: {
     signature: string
     message: string
     walletClientType: string
     connectorType: string
     address: string
+    chainId?: number
   }): Promise<AuthResponse> {
     await this.ensureInitialized()
     const auth = await Authentication.fromStorage(this.storage)
@@ -392,7 +394,8 @@ export class AuthApi {
         message,
         walletClientType,
         connectorType,
-        address
+        address,
+        chainId
       )
       new Authentication('session', result.token!, result.user?.id).save(this.storage)
       this.eventEmitter.emit(OpenfortEvents.ON_AUTH_SUCCESS, result)

--- a/sdk/src/auth/authManager.test.ts
+++ b/sdk/src/auth/authManager.test.ts
@@ -1,0 +1,86 @@
+import type { BackendApiClients } from '@openfort/openapi-clients'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthManager } from './authManager'
+
+// cspell:disable
+describe('AuthManager SIWE chainId', () => {
+  const PUBLISHABLE_KEY = 'pk_test_123'
+  const ADDRESS = '0x1234567890123456789012345678901234567890'
+  const EXPECTED_HEADERS = { headers: { 'x-project-key': PUBLISHABLE_KEY } }
+
+  let siweNoncePost: ReturnType<typeof vi.fn>
+  let siweVerifyPost: ReturnType<typeof vi.fn>
+  let authManager: AuthManager
+
+  beforeEach(() => {
+    siweNoncePost = vi.fn().mockResolvedValue({ data: { nonce: 'nonce-abc' } })
+    siweVerifyPost = vi.fn().mockResolvedValue({
+      data: { token: 'session-token', user: { id: 'user-1' } },
+    })
+
+    const backendApiClients = {
+      authApi: { siweNoncePost, siweVerifyPost },
+    } as unknown as BackendApiClients
+
+    authManager = new AuthManager()
+    authManager.setBackendApiClients(backendApiClients, PUBLISHABLE_KEY)
+  })
+
+  describe('initSIWE', () => {
+    it('forwards chainId to the nonce request when provided', async () => {
+      await authManager.initSIWE(ADDRESS, 84532)
+
+      expect(siweNoncePost).toHaveBeenCalledWith(
+        { siweNoncePostRequest: { walletAddress: ADDRESS, chainId: 84532 } },
+        EXPECTED_HEADERS
+      )
+    })
+
+    it('omits chainId from the nonce request when not provided', async () => {
+      await authManager.initSIWE(ADDRESS)
+
+      expect(siweNoncePost).toHaveBeenCalledWith({ siweNoncePostRequest: { walletAddress: ADDRESS } }, EXPECTED_HEADERS)
+      const [[request]] = siweNoncePost.mock.calls
+      expect(request.siweNoncePostRequest).not.toHaveProperty('chainId')
+    })
+  })
+
+  describe('authenticateSIWE', () => {
+    const SIG = '0xsignature'
+    const MESSAGE = 'siwe message'
+    const WALLET_CLIENT_TYPE = 'metaMask'
+    const CONNECTOR_TYPE = 'injected'
+
+    it('forwards chainId to the verify request when provided', async () => {
+      await authManager.authenticateSIWE(SIG, MESSAGE, WALLET_CLIENT_TYPE, CONNECTOR_TYPE, ADDRESS, 84532)
+
+      expect(siweVerifyPost).toHaveBeenCalledWith(
+        {
+          siweVerifyPostRequest: {
+            signature: SIG,
+            walletAddress: ADDRESS,
+            message: MESSAGE,
+            walletClientType: WALLET_CLIENT_TYPE,
+            connectorType: CONNECTOR_TYPE,
+            chainId: 84532,
+          },
+        },
+        EXPECTED_HEADERS
+      )
+    })
+
+    it('omits chainId from the verify request when not provided', async () => {
+      await authManager.authenticateSIWE(SIG, MESSAGE, WALLET_CLIENT_TYPE, CONNECTOR_TYPE, ADDRESS)
+
+      const [[request]] = siweVerifyPost.mock.calls
+      expect(request.siweVerifyPostRequest).not.toHaveProperty('chainId')
+      expect(request.siweVerifyPostRequest).toEqual({
+        signature: SIG,
+        walletAddress: ADDRESS,
+        message: MESSAGE,
+        walletClientType: WALLET_CLIENT_TYPE,
+        connectorType: CONNECTOR_TYPE,
+      })
+    })
+  })
+})

--- a/sdk/src/auth/authManager.ts
+++ b/sdk/src/auth/authManager.ts
@@ -234,10 +234,11 @@ export class AuthManager {
     )
   }
 
-  public async initSIWE(address: string): Promise<SIWEInitResponse> {
+  public async initSIWE(address: string, chainId?: number): Promise<SIWEInitResponse> {
     const request: SIWEApiSiweNoncePostRequest = {
       siweNoncePostRequest: {
         walletAddress: address,
+        ...(chainId === undefined ? {} : { chainId }),
       },
     }
     const result = await withApiError(
@@ -291,7 +292,8 @@ export class AuthManager {
     message: string,
     walletClientType: string,
     connectorType: string,
-    address: string
+    address: string,
+    chainId?: number
   ): Promise<AuthResponse> {
     const request: SIWEApiSiweVerifyPostRequest = {
       siweVerifyPostRequest: {
@@ -300,6 +302,7 @@ export class AuthManager {
         message,
         walletClientType,
         connectorType,
+        ...(chainId === undefined ? {} : { chainId }),
       },
     }
     return withApiError<AuthResponse>(


### PR DESCRIPTION
## Problem

SIWE login fails with `401 UNAUTHORIZED_SIWE_MESSAGE_MISMATCH` ("SIWE message does not match the expected nonce, domain, address, or chain ID") on any non-mainnet chain (e.g. Base Sepolia `84532`).

Root cause: the login flow (`auth.initSiwe` → `auth.loginWithSiwe`) never sent `chainId` to `/siwe/nonce` or `/siwe/verify`. The API defaults the request `chainId` to `1`. /siwe/verify` compares that request `chainId` against the `Chain ID` embedded in the signed SIWE message and rejects any mismatch — `84532 !== 1` → fail. On ≤1.5.x this check didn't exist, which is why this surfaced without any SDK change.

The generated request models already expose the field (`SiweNoncePostRequest.chainId?`, `SiweVerifyPostRequest.chainId?` — the latter documented as *"must match the Chain ID in SIWE message"*); the SDK just wasn't populating it.

## Change

`auth.initSiwe({ address })` and `auth.loginWithSiwe({ … })` now accept an optional `chainId`, forwarded through `AuthManager.initSIWE` / `authenticateSIWE` into the `/siwe/nonce` and `/siwe/verify` request bodies. Sending the same `chainId` to both keeps the nonce bucket (`siwe:${address}:${chainId}`) consistent and makes the verify chain-ID check pass.

**Backward compatible:** omitting `chainId` preserves the previous default-to-1 behavior. Scoped to the login/new-session path (the reproduced failure); the link path is unchanged.

## Not fixed here (tracked separately)

- **`@openfort/react` companion:** `useConnectWithSiwe` / `useWalletAuth` must pass the connected wallet's `chainId` (already computed in those hooks) into `initSiwe` / `loginWithSiwe` for this to take effect at runtime.
- **API domain check (primary blocker):** the same better-auth 1.6.x verify also requires the message `domain` to equal the plugin's configured `domain`, which the API hardcodes to a placeholder `"openfort.xyz"` while the SDK correctly signs the real host. That must be fixed API-side.

## Verification

- `sdk` typecheck: no new errors (the 3 pre-existing `funding.ts` errors are unrelated / stale `dist`).
- `vitest run src/api/auth.test.ts` — 20/20 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)