### PR TITLE
chore(observability): improve SDK error monitoring

### DIFF
--- a/.changeset/quiet-spies-monitor.md
+++ b/.changeset/quiet-spies-monitor.md
@@ -1,0 +1,5 @@
+---
+'@openfort/openfort-js': patch
+---
+
+Improve anonymous error telemetry with consistent SDK, runtime, project, release, and environment metadata; redact sensitive request data; filter expected user errors; report only terminal iframe handshake failures; and publish source maps with SDK bundles.

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -21,6 +21,7 @@ const modules = {
     dir: 'dist',
     format: 'es',
     preserveModules: true,
+    sourcemap: true,
   },
   plugins: [
     nodeResolve({
@@ -64,6 +65,7 @@ const cjs = {
     preserveModules: true,
     entryFileNames: '[name].cjs',
     chunkFileNames: '[name].cjs',
+    sourcemap: true,
   },
   plugins: [
     nodeResolve({

--- a/sdk/src/core/errors/sentry.test.ts
+++ b/sdk/src/core/errors/sentry.test.ts
@@ -1,6 +1,7 @@
 import type { OpenfortSDKConfiguration } from 'types'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PACKAGE, VERSION } from '../../version'
+import { OpenfortError, SignerError } from './openfortError'
 
 // Each test re-imports ./sentry after configuring the mock, so the static
 // InternalSentry singleton starts fresh and the dynamic import('@sentry/browser')
@@ -11,7 +12,16 @@ afterEach(() => {
 })
 
 const makeConfig = (disableTelemetry?: boolean) =>
-  ({ baseConfiguration: { publishableKey: 'pk_test' }, disableTelemetry }) as unknown as OpenfortSDKConfiguration
+  ({
+    baseConfiguration: { publishableKey: 'pk_test_project' },
+    disableTelemetry,
+  }) as unknown as OpenfortSDKConfiguration
+
+const dsn = {
+  projectId: '4509292415287296',
+  host: 'o4504593015242752.ingest.us.sentry.io',
+  publicKey: '64a03e4967fb4dad3ecb914918c777b6',
+}
 
 // Mock @sentry/browser with a BrowserClient that records its constructor options
 // and satisfies the DSN validation in InternalSentry's `set sentry`. Returns the
@@ -25,11 +35,7 @@ const mockSentryBrowser = (): Record<string, unknown>[] => {
       }
 
       getDsn() {
-        return {
-          projectId: '4509292415287296',
-          host: 'o4504593015242752.ingest.us.sentry.io',
-          publicKey: '64a03e4967fb4dad3ecb914918c777b6',
-        }
+        return dsn
       }
     },
     defaultStackParser: {},
@@ -64,5 +70,69 @@ describe('InternalSentry.init', () => {
     await InternalSentry.init({ configuration: makeConfig(false) })
     expect(ctorOptions).toHaveLength(1)
     expect(ctorOptions[0]?.release).toBe(`${PACKAGE}@${VERSION}`)
+    expect(ctorOptions[0]?.environment).toBe('test')
+  })
+
+  it('adds searchable SDK metadata and strips sensitive event data', async () => {
+    const ctorOptions = mockSentryBrowser()
+    const { InternalSentry } = await import('./sentry')
+    await InternalSentry.init({ configuration: makeConfig(false) })
+
+    const beforeSend = ctorOptions[0]?.beforeSend as (event: Record<string, any>) => Record<string, any>
+    const event = beforeSend({
+      contexts: { auth: { accessToken: 'secret', provider: 'google' } },
+      extra: { password: 'secret', safe: { value: 1 } },
+      request: {
+        cookies: { session: 'secret' },
+        data: { password: 'secret' },
+        headers: { authorization: 'Bearer secret' },
+        method: 'POST',
+        url: 'https://example.com/callback?token=secret#fragment',
+      },
+      tags: { operation: 'login' },
+    })
+
+    expect(event.contexts).toEqual({ auth: { accessToken: '[Filtered]', provider: 'google' } })
+    expect(event.extra).toEqual({ password: '[Filtered]', safe: { value: 1 } })
+    expect(event.request).toEqual({ method: 'POST', url: 'https://example.com/callback' })
+    expect(event.tags).toMatchObject({
+      operation: 'login',
+      projectEnvironment: 'test',
+      projectId: 'pk_test_project',
+      sdkName: PACKAGE,
+      sdkVersion: VERSION,
+    })
+  })
+
+  it('does not report expected user errors', async () => {
+    const captureException = vi.fn()
+    const client = { captureException, getDsn: () => dsn }
+    const { InternalSentry } = await import('./sentry')
+    await InternalSentry.init({ sentry: client as any, configuration: makeConfig() })
+
+    InternalSentry.sentry.captureError('verifyOtp', new OpenfortError('INVALID_OTP', 'Invalid OTP'))
+
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  it('reports actionable errors without account identifiers', async () => {
+    const captureException = vi.fn()
+    const client = { captureException, getDsn: () => dsn }
+    const { InternalSentry } = await import('./sentry')
+    await InternalSentry.init({ sentry: client as any, configuration: makeConfig() })
+
+    InternalSentry.sentry.captureError(
+      'createSigner',
+      new SignerError('signer_unavailable', 'Signer unavailable', 'account-sensitive')
+    )
+
+    expect(captureException).toHaveBeenCalledOnce()
+    const hint = captureException.mock.calls[0]?.[1]
+    expect(hint.captureContext.extra).not.toHaveProperty('accountId')
+    expect(hint.captureContext.tags).toMatchObject({
+      context: 'createSigner',
+      sdkName: PACKAGE,
+      sdkVersion: VERSION,
+    })
   })
 })

--- a/sdk/src/core/errors/sentry.ts
+++ b/sdk/src/core/errors/sentry.ts
@@ -5,6 +5,86 @@ import { PACKAGE, VERSION } from '../../version'
 
 const SENTRY_DSN = 'https://64a03e4967fb4dad3ecb914918c777b6@o4504593015242752.ingest.us.sentry.io/4509292415287296' // Prod
 
+const EXPECTED_ERROR_CODES = new Set([
+  'ALREADY_LOGGED_IN',
+  'INVALID_EMAIL',
+  'INVALID_EMAIL_OR_PASSWORD',
+  'INVALID_OTP',
+  'INVALID_PASSWORD',
+  'INVALID_TOKEN',
+  'NOT_LOGGED_IN',
+  'OTP_EXPIRED',
+  'SESSION_EXPIRED',
+  'USER_ALREADY_EXISTS',
+  'USER_EMAIL_NOT_FOUND',
+  'USER_NOT_AUTHORIZED',
+  'USER_NOT_FOUND',
+])
+
+const EXPECTED_HTTP_STATUSES = new Set([400, 401, 403, 409, 422, 429])
+const SENSITIVE_KEY = /authorization|cookie|credential|password|secret|token/i
+
+type BaseTags = {
+  projectEnvironment: 'production' | 'test' | 'unknown'
+  projectId: string
+  sdkName: string
+  sdkRuntime: 'browser' | 'react-native' | 'server'
+  sdkVersion: string
+}
+
+const getProjectEnvironment = (publishableKey: string): BaseTags['projectEnvironment'] => {
+  if (publishableKey.startsWith('pk_live_')) return 'production'
+  if (publishableKey.startsWith('pk_test_')) return 'test'
+  return 'unknown'
+}
+
+const getRuntime = (): BaseTags['sdkRuntime'] => {
+  if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') return 'react-native'
+  if (typeof window !== 'undefined') return 'browser'
+  return 'server'
+}
+
+const redactRecord = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(redactRecord)
+  if (!value || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, SENSITIVE_KEY.test(key) ? '[Filtered]' : redactRecord(entry)])
+  )
+}
+
+const sanitizeUrl = (value?: string): string | undefined => {
+  if (!value) return undefined
+  try {
+    const url = new URL(value)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return value.split(/[?#]/, 1)[0]
+  }
+}
+
+const getErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined
+  const candidate = error as { error?: unknown; response?: { data?: unknown } }
+  if (typeof candidate.error === 'string') return candidate.error
+
+  const data = candidate.response?.data
+  if (!data || typeof data !== 'object') return undefined
+  const response = data as { code?: unknown; error?: unknown }
+  if (typeof response.code === 'string') return response.code
+  if (typeof response.error === 'string') return response.error
+  if (response.error && typeof response.error === 'object' && 'code' in response.error) {
+    const nestedCode = (response.error as { code?: unknown }).code
+    return typeof nestedCode === 'string' ? nestedCode : undefined
+  }
+  return undefined
+}
+
+const shouldCapture = (error: unknown, statusCode?: number): boolean => {
+  const errorCode = getErrorCode(error)
+  return !(statusCode && EXPECTED_HTTP_STATUSES.has(statusCode)) && !(errorCode && EXPECTED_ERROR_CODES.has(errorCode))
+}
+
 declare module '@sentry/core' {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   interface Client {
@@ -19,11 +99,7 @@ export class InternalSentry {
 
   private static queuedCalls: Array<{ fn: string; args: any[] }> = []
 
-  private static baseTags: {
-    projectId: string
-    sdk: string
-    sdkVersion: string
-  }
+  private static baseTags: BaseTags
 
   private static set sentry(sentry: Client) {
     // eslint-disable-next-line no-param-reassign
@@ -43,8 +119,7 @@ export class InternalSentry {
     // eslint-disable-next-line no-param-reassign
     sentry.captureAxiosError = (method: string, error: unknown, hint?: EventHint, scope?: Scope) => {
       if (error instanceof AxiosError) {
-        // Skip Sentry notification for 400 and 401 errors
-        if (error.response?.status === 400 || error.response?.status === 401) {
+        if (!shouldCapture(error, error.response?.status)) {
           return
         }
         // eslint-disable-next-line no-param-reassign
@@ -54,10 +129,8 @@ export class InternalSentry {
           captureContext: {
             ...hint?.captureContext,
             extra: {
-              errorResponseData: error.response?.data,
+              errorCode: getErrorCode(error),
               errorStatus: error.response?.status,
-              errorHeaders: error.response?.headers,
-              errorRequest: error.request,
             },
             tags: {
               ...InternalSentry.baseTags,
@@ -72,18 +145,14 @@ export class InternalSentry {
 
     // eslint-disable-next-line no-param-reassign
     sentry.captureError = (context: string, error: Error, hint?: EventHint, _scope?: Scope) => {
-      // Skip Sentry notification for 400 and 401 errors
-      // Check both AuthenticationError.statusCode and RequestError.statusCode
       const statusCode = (error as any).statusCode
-      if (statusCode === 400 || statusCode === 401) {
+      if (!shouldCapture(error, statusCode)) {
         return
       }
 
       // Extract error properties for OpenfortError instances
       const openfortError = error as any
       const errorCode = openfortError.error
-      const errorDescription = openfortError.error_description
-
       const captureContext = hint?.captureContext as any
       sentry.captureException(error, {
         ...hint,
@@ -92,7 +161,6 @@ export class InternalSentry {
           extra: {
             ...captureContext?.extra,
             errorCode,
-            errorDescription,
             errorClass: error.constructor.name,
             // Include specific error properties based on type
             ...(openfortError.statusCode && {
@@ -100,10 +168,6 @@ export class InternalSentry {
             }),
             ...(openfortError.audience && { audience: openfortError.audience }),
             ...(openfortError.scope && { scope: openfortError.scope }),
-            ...(openfortError.accountId && {
-              accountId: openfortError.accountId,
-            }),
-            ...(openfortError.userId && { userId: openfortError.userId }),
             ...(openfortError.provider && { provider: openfortError.provider }),
             ...(openfortError.recoveryMethod && {
               recoveryMethod: openfortError.recoveryMethod,
@@ -132,6 +196,15 @@ export class InternalSentry {
     sentry?: Client
     configuration?: OpenfortSDKConfiguration
   }): Promise<void> {
+    const publishableKey = configuration?.baseConfiguration.publishableKey ?? ''
+    InternalSentry.baseTags = {
+      projectEnvironment: getProjectEnvironment(publishableKey),
+      projectId: publishableKey,
+      sdkName: PACKAGE,
+      sdkRuntime: getRuntime(),
+      sdkVersion: VERSION,
+    }
+
     if (sentry) {
       InternalSentry.sentry = sentry
       return
@@ -156,17 +229,29 @@ export class InternalSentry {
       // that previously reported release: null now carry the SDK version.
       InternalSentry.sentry = new sentryImport.BrowserClient({
         dsn: SENTRY_DSN,
+        environment: InternalSentry.baseTags.projectEnvironment,
         release: `${PACKAGE}@${VERSION}`,
         integrations: [],
         stackParser: sentryImport.defaultStackParser,
         transport: sentryImport.makeFetchTransport,
+        beforeSend(event) {
+          return {
+            ...event,
+            contexts: redactRecord(event.contexts) as typeof event.contexts,
+            extra: redactRecord(event.extra) as typeof event.extra,
+            request: event.request
+              ? {
+                  method: event.request.method,
+                  url: sanitizeUrl(event.request.url),
+                }
+              : undefined,
+            tags: {
+              ...event.tags,
+              ...InternalSentry.baseTags,
+            },
+          }
+        },
       })
-
-      InternalSentry.baseTags = {
-        projectId: configuration?.baseConfiguration.publishableKey ?? '',
-        sdk: PACKAGE,
-        sdkVersion: VERSION,
-      }
 
       InternalSentry.processQueuedCalls()
     } catch {

--- a/sdk/src/wallets/iframeManager.test.ts
+++ b/sdk/src/wallets/iframeManager.test.ts
@@ -47,6 +47,7 @@ vi.mock('../core/errors/sentry', () => ({
   },
 }))
 
+import { sentry } from '../core/errors/sentry'
 import { connect, PenpalError } from './messaging/browserMessenger'
 
 type Deferred<T> = {
@@ -295,6 +296,8 @@ describe('IframeManager handshake-timeout discriminator (OPENFORT-JS-D0)', () =>
     expect(message).not.toMatch(/configure your origin/i)
     // The original PenpalError is preserved for programmatic routing.
     expect((caught as { cause?: unknown }).cause).toBe(penpalError)
+    expect(sentry.captureException).toHaveBeenCalledOnce()
+    expect(sentry.captureException).toHaveBeenCalledWith(caught)
   })
 
   it('keeps the "configure your origin" hint for non-timeout handshake failures', async () => {
@@ -718,6 +721,7 @@ describe('IframeManager connection-lost notifications', () => {
     )
 
     expect(onConnectionLost).not.toHaveBeenCalled()
+    expect(sentry.captureException).not.toHaveBeenCalled()
   })
 
   it('does NOT notify when the logout RPC times out (intentional teardown)', async () => {

--- a/sdk/src/wallets/iframeManager.ts
+++ b/sdk/src/wallets/iframeManager.ts
@@ -489,6 +489,12 @@ export class IframeManager {
       if (error instanceof SessionEndedBeforeSetupError) {
         throw error
       }
+      // Only report terminal handshake failures. Callers which transparently
+      // retry suppress the first attempt, so a recovered timeout never creates
+      // a noisy Sentry issue.
+      if (!this.suppressHandshakeLostNotify) {
+        sentry.captureException(error)
+      }
       // Mark as failed so this instance won't be reused
       this.hasFailed = true
       throw error
@@ -545,7 +551,6 @@ export class IframeManager {
         debugLog('Connection rejected after destroy() — surfacing teardown error')
       }
       this.assertAlive()
-      sentry.captureException(error)
       // Internal cleanup only — do NOT mark `isDestroyed`. The consumer hasn't
       // torn the manager down; the handshake itself failed. Marking it
       // destroyed here would shadow the genuine "configure your origin" hint


### PR DESCRIPTION
## Summary

- attach release, environment, project, SDK version, and runtime metadata to every SDK-owned Sentry event
- filter expected authentication/user failures and non-actionable client responses
- redact sensitive event fields and stop forwarding raw Axios requests, headers, and response bodies
- report only terminal iframe handshake failures, avoiding noise from recovered retry attempts
- publish ESM and CJS source maps and include a patch changeset

## Validation

- `vitest run src/core/errors/sentry.test.ts src/wallets/iframeManager.test.ts` (57 tests)
- `tsc --noEmit`
- `biome check`
- production SDK build (146 source maps with embedded sources)
- `pnpm test:build` (`publint` and `attw`)

Sentry ownership, alert thresholds, inbound filters, and server-side scrubbing remain project-side follow-up configuration.

Prompted by: Jaume Alavedra