### PR TITLE
fix(evm): don't probe the network to serve eth_requestAccounts

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -5,3 +5,5 @@
 Stop probing the network to serve `eth_requestAccounts`. The chain id it reports is now resolved from the stored account (or the configured chains), the same way `getRpcProvider` already resolves it, instead of via a live `detectNetwork()` call whose only use was the `connect` event payload. Listing a locally-stored account no longer fails with `could not detect network` when the RPC endpoint is slow, rate-limited or unreachable — which surfaced as "Error creating wallet" during embedded wallet creation, including for EOAs that never touch an RPC.
 
 `StaticJsonRpcProvider` is now also constructed with an explicit chain id, so it issues no detection round-trip and cannot cache a rejected network promise for the rest of the session.
+
+The cached provider is also dropped on account switch (it already was on logout), so after switching to an account on a different chain, `eth_chainId` and pass-through RPC calls follow the new account instead of staying pinned to the previous chain.

--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,7 @@
+---
+'@openfort/openfort-js': patch
+---
+
+Stop probing the network to serve `eth_requestAccounts`. The chain id it reports is now resolved from the stored account (or the configured chains), the same way `getRpcProvider` already resolves it, instead of via a live `detectNetwork()` call whose only use was the `connect` event payload. Listing a locally-stored account no longer fails with `could not detect network` when the RPC endpoint is slow, rate-limited or unreachable — which surfaced as "Error creating wallet" during embedded wallet creation, including for EOAs that never touch an RPC.
+
+`StaticJsonRpcProvider` is now also constructed with an explicit chain id, so it issues no detection round-trip and cannot cache a rejected network promise for the rest of the session.

--- a/sdk/src/wallets/evm/evmProvider.test.ts
+++ b/sdk/src/wallets/evm/evmProvider.test.ts
@@ -112,6 +112,20 @@ describe('EvmProvider signer cache vs connection loss', () => {
     // serving the previous session's provider would hit the wrong network.
     expect(await provider.getRpcProvider()).not.toBe(before)
   })
+
+  it('drops the cached RPC provider on account switch', async () => {
+    const { provider, openfortEventEmitter } = makeCachedSignerProvider()
+
+    const before = await provider.getRpcProvider()
+
+    openfortEventEmitter.emit(OpenfortEvents.ON_SWITCH_ACCOUNT, '0xdef')
+
+    // The switched-to account may live on a different chain. Serving the old
+    // provider would leave eth_chainId and pass-through RPC calls on the
+    // previous account's chain while eth_requestAccounts (which re-reads
+    // storage) reports the new one.
+    expect(await provider.getRpcProvider()).not.toBe(before)
+  })
 })
 
 describe('EvmProvider RPC endpoint resolution', () => {

--- a/sdk/src/wallets/evm/evmProvider.test.ts
+++ b/sdk/src/wallets/evm/evmProvider.test.ts
@@ -148,4 +148,64 @@ describe('EvmProvider RPC endpoint resolution', () => {
 
     await expect(provider.getRpcProvider()).rejects.toThrow(/No RPC URL configured for chain 1234567/)
   })
+
+  it('pins the network on construction so no eth_chainId round-trip is needed', async () => {
+    // Without the explicit network argument ethers schedules a detection
+    // request and caches the resulting promise — including when it rejects.
+    const rpcProvider = await makeProviderOnChain(8453).getRpcProvider()
+
+    expect(rpcProvider.network.chainId).toBe(8453)
+  })
+})
+
+describe('EvmProvider eth_requestAccounts', () => {
+  const makeConnectProvider = (account: Record<string, unknown>, chains?: Record<number, string>) => {
+    const storage = makeStorage()
+    vi.mocked(storage.get).mockResolvedValue(JSON.stringify(account))
+
+    const provider = new EvmProvider({
+      storage,
+      backendApiClients: {} as any,
+      openfortEventEmitter: new TypedEventEmitter<any>(),
+      ensureSigner: vi.fn(async () => ({}) as any),
+      validateAndRefreshSession: vi.fn().mockResolvedValue(undefined),
+      chains,
+    })
+
+    // Any RPC access at all is the regression: serving a stored account must
+    // not depend on the network, so the spy rejects rather than stubbing.
+    const getRpcProvider = vi
+      .spyOn(provider, 'getRpcProvider')
+      .mockRejectedValue(new Error('could not detect network (event="noNetwork", code=NETWORK_ERROR)'))
+
+    const connects: unknown[] = []
+    provider.on('connect', (payload: unknown) => connects.push(payload))
+
+    return { provider, getRpcProvider, connects }
+  }
+
+  it('returns the account and emits connect without touching the RPC provider', async () => {
+    const { provider, getRpcProvider, connects } = makeConnectProvider({
+      id: 'acc_1',
+      chainId: 1,
+      address: '0xabc',
+    })
+
+    await expect(provider.request({ method: 'eth_requestAccounts' })).resolves.toEqual(['0xabc'])
+    expect(getRpcProvider).not.toHaveBeenCalled()
+    expect(connects).toEqual([{ chainId: '0x1' }])
+  })
+
+  it('falls back to the first configured chain for an EOA, which stores no chainId', async () => {
+    const { provider, getRpcProvider, connects } = makeConnectProvider(
+      { id: 'acc_1', address: '0xabc' },
+      {
+        11155111: 'https://sepolia.example',
+      }
+    )
+
+    await expect(provider.request({ method: 'eth_requestAccounts' })).resolves.toEqual(['0xabc'])
+    expect(getRpcProvider).not.toHaveBeenCalled()
+    expect(connects).toEqual([{ chainId: '0xaa36a7' }])
+  })
 })

--- a/sdk/src/wallets/evm/evmProvider.ts
+++ b/sdk/src/wallets/evm/evmProvider.ts
@@ -127,6 +127,11 @@ export class EvmProvider implements Provider {
   }
 
   #handleSwitchAccount = async (address: string) => {
+    // The switched-to account may live on a different chain — drop the cached
+    // provider so the next request rebuilds it from the freshly-stored
+    // account, keeping eth_chainId and pass-through RPC calls consistent with
+    // the chain eth_requestAccounts reports.
+    this.#rpcProvider = null
     this.#eventEmitter.emit(ProviderEvent.ACCOUNTS_CHANGED, [address])
   }
 

--- a/sdk/src/wallets/evm/evmProvider.ts
+++ b/sdk/src/wallets/evm/evmProvider.ts
@@ -148,18 +148,29 @@ export class EvmProvider implements Provider {
     return rpcUrl
   }
 
+  /**
+   * Resolves the chain the provider operates on, without touching the network.
+   *
+   * @returns The account's chain id, else the first caller-supplied chain, else Base mainnet.
+   */
+  async #resolveChainId(): Promise<number> {
+    const account = await Account.fromStorage(this.#storage)
+    // when accountTypeEnum is EOA, account.chainId will be undefined.
+    // we will always return the first configured chain in the provider if one is provided.
+    // otherwise we revert to 8453
+    return account?.chainId || (this.#customChains ? Number(Object.keys(this.#customChains)[0]) : undefined) || 8453
+  }
+
   async getRpcProvider(): Promise<StaticJsonRpcProvider> {
     if (!this.#rpcProvider) {
-      const account = await Account.fromStorage(this.#storage)
-      // when accountTypeEnum is EOA, account.chainId will be undefined.
-      // we will always return the first configured chain in the provider if one is provided.
-      // otherwise we revert to 8453
-      const chainId =
-        account?.chainId || (this.#customChains ? Number(Object.keys(this.#customChains)[0]) : undefined) || 8453
-
+      const chainId = await this.#resolveChainId()
       const rpcUrl = this.#resolveRpcUrl(chainId)
       await import('@ethersproject/providers').then((module) => {
-        this.#rpcProvider = new module.StaticJsonRpcProvider(rpcUrl)
+        // The chain is passed explicitly so the provider never issues a
+        // detection round-trip on construction. ethers v5 caches a *rejected*
+        // network promise, so a single dropped eth_chainId would otherwise
+        // poison this provider for the rest of the session.
+        this.#rpcProvider = new module.StaticJsonRpcProvider(rpcUrl, chainId)
       })
     }
     if (!this.#rpcProvider) {
@@ -178,8 +189,13 @@ export class EvmProvider implements Provider {
       case 'eth_requestAccounts': {
         const account = await Account.fromStorage(this.#storage)
         if (account) {
-          const rpcProvider = await this.getRpcProvider()
-          const { chainId } = await rpcProvider.detectNetwork()
+          // Deliberately not via getRpcProvider().detectNetwork(): the chain id
+          // is only used to fill the connect event payload, so probing an RPC
+          // here would gate listing a locally-stored account on a network call
+          // the account itself never needs. For an EOA that probe hits whatever
+          // chain we defaulted to, and a failure surfaced as a wallet-creation
+          // error.
+          const chainId = await this.#resolveChainId()
           this.#eventEmitter.emit(ProviderEvent.ACCOUNTS_CONNECT, {
             chainId: numberToHex(chainId),
           })
@@ -382,7 +398,7 @@ export class EvmProvider implements Provider {
         try {
           await signer.switchChain({ chainId: chainIdNumber })
           await import('@ethersproject/providers').then((module) => {
-            this.#rpcProvider = new module.StaticJsonRpcProvider(rpcUrl)
+            this.#rpcProvider = new module.StaticJsonRpcProvider(rpcUrl, chainIdNumber)
           })
           this.#eventEmitter.emit(ProviderEvent.CHAIN_CHANGED, numberToHex(chainIdNumber))
         } catch (error) {

--- a/sdk/src/wallets/evm/evmProvider.ts
+++ b/sdk/src/wallets/evm/evmProvider.ts
@@ -374,12 +374,9 @@ export class EvmProvider implements Provider {
         })
       }
       case 'eth_chainId': {
-        // Call detect network to fetch the chainId so to take advantage of
-        // the caching layer provided by StaticJsonRpcProvider.
-        // In case Openfort is changed from StaticJsonRpcProvider to a
-        // JsonRpcProvider, this function will still work as expected given
-        // that detectNetwork call _uncachedDetectNetwork which will force
-        // the provider to re-fetch the chainId from remote.
+        // The provider is constructed with an explicit network, so
+        // detectNetwork() resolves from the pinned value — no eth_chainId
+        // round-trip and no dependency on RPC availability.
         const rpcProvider = await this.getRpcProvider()
         const { chainId } = await rpcProvider.detectNetwork()
         return numberToHex(chainId)


### PR DESCRIPTION
## Problem

Creating an embedded wallet intermittently failed with:

```
Error creating wallet.
could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.8.0)
```

`eth_requestAccounts` is the only ethers call in the create path, and it read the chain id from a live `getRpcProvider().detectNetwork()` — a real `eth_chainId` POST. The only use of the result was `numberToHex(chainId)` in the `connect` event payload. Compare `eth_accounts` right above it: same answer, pure storage read, no network.

So listing a locally-stored account was gated on an RPC round-trip the account never needs. For the default EOA account type `account.chainId` is undefined, so the probe went to whatever chain we fell back to — Base mainnet on the shared public endpoint — and a slow, rate-limited or dropped response rejected the whole request. Even on success the announced chain id was wrong for an EOA (`8453`, by fallback, regardless of the app's chain), and nothing in the React SDK subscribes to that `connect` event.

Two things made it stickier. ethers v5 caches the network promise **including when it rejects**, and `#rpcProvider` is only cleared on logout — so a retry couldn't recover. Safari's lower connection limits and its habit of aborting in-flight fetches on iframe teardown made the first attempt lose more often, which is where this was reported.

## Change

- Extract `#resolveChainId()` from `getRpcProvider()` — the same `account.chainId → first configured chain → 8453` resolution, without a network call — and use it in `eth_requestAccounts`. Both paths now agree on the chain id and neither invents one.
- Pass that chain id as the second `StaticJsonRpcProvider` argument at both construction sites (`getRpcProvider`, `wallet_switchEthereumChain`). No detection round-trip on construction, and no cached-rejected-network dead end for the paths that do legitimately need RPC. As a side effect `eth_chainId` is served from the pinned network rather than the wire.

No behaviour change for callers: `eth_requestAccounts` returns the same array and emits the same event shape.

## Tests

Three added, all verified to fail against the unpatched source (stashed the change in `evmProvider.ts`, kept the tests):

- `eth_requestAccounts` resolves and emits `{chainId: '0x1'}` while `getRpcProvider` is spied to reject with the exact `noNetwork` error — so any RPC access at all fails the test rather than being silently stubbed.
- The EOA case (account with no `chainId`) falls back to the first configured chain and emits `0xaa36a7`, not Base.
- `getRpcProvider()` returns a provider whose `network` is already populated.

`277/277` unit tests pass (274 before), `tsc --noEmit -p sdk` clean, `biome check` clean on `sdk/src/wallets/evm/`. Changeset added (patch).

## Related

Companion fix in openfort-react: openfort-xyz/openfort-react#320 — the create path there builds this provider without passing `rpcUrls`, which is why the fallback chain was reached in the first place.

Prompted by: Joan Alavedra


## Review follow-ups

- Updated the `eth_chainId` comment, which still described `detectNetwork()` fetching the chain id from the wire.
- The cached `StaticJsonRpcProvider` is now also dropped on `ON_SWITCH_ACCOUNT` (it already was on logout). configure/create/import/recover store the new account and emit that event, but the provider kept the instance built for the previous account — leaving `eth_chainId` and pass-through RPC calls on the old chain while `eth_requestAccounts` reported the new one. Test added; verified to fail without the fix.
