### PR TITLE
Unblock the release pipeline and skip E2E on Dependabot PRs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,11 @@ jobs:
   # chromium/firefox/webkit. The connection-reliability spec is guest-based
   # and runs in the parallel `reliability` job below instead.
   test:
+    # Dependabot-triggered runs receive repository variables but not Actions
+    # secrets, so the auth-sample server cannot start authenticated flows and
+    # every test fails. The merge_group trigger still runs the suite with real
+    # secrets before anything lands on main.
+    if: github.actor != 'dependabot[bot]'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
@@ -104,6 +109,8 @@ jobs:
   # it never touches the shared E2E account and can run in parallel with the
   # main job. Chromium only by design.
   reliability:
+    # Same secrets restriction as `test` above.
+    if: github.actor != 'dependabot[bot]'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:

--- a/.husky/run_gitleaks.sh
+++ b/.husky/run_gitleaks.sh
@@ -6,8 +6,16 @@ set -euo pipefail
 if command -v gitleaks >/dev/null 2>&1; then
     gitleaks git --staged --redact -v
 elif [[ "$(uname)" == "Linux" ]] && command -v docker >/dev/null 2>&1; then
-    docker run --rm -v "$(pwd)":/path ghcr.io/gitleaks/gitleaks:latest \
-        git --source="/path" --staged --redact -v
+    # `gitleaks git` takes the repo as a positional argument; `--source` only
+    # exists on the deprecated subcommands and fails the commit. The image is
+    # pinned to the version CI uses rather than `latest`, and the container's
+    # git needs the bind-mounted repo marked safe: it runs as root while the
+    # mount is owned by the host user.
+    docker run --rm -v "$(pwd)":/path \
+        -e GIT_CONFIG_COUNT=1 \
+        -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0=/path \
+        ghcr.io/gitleaks/gitleaks:v8.30.1 \
+        git --staged --redact -v /path
 else
     echo "gitleaks is not installed and no Docker fallback is available."
     echo "Install it: https://github.com/gitleaks/gitleaks#installing"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:types": "pnpm --filter @openfort/openfort-js test:types",
     "clean": "rm -rf sdk/dist",
     "check:unused": "pnpm clean && knip",
-    "postinstall": "simple-git-hooks && ./.husky/install_gitleaks.sh",
+    "postinstall": "[ -n \"$CI\" ] || { simple-git-hooks && ./.husky/install_gitleaks.sh; }",
     "scan:secrets": "./.husky/run_gitleaks.sh",
     "stats": "pnpm --filter @openfort/openfort-js stats",
     "dev": "pnpm --filter @openfort/openfort-js dev",


### PR DESCRIPTION
### Description

Two CI fixes, no published-package changes (no changeset needed).

**Release pipeline.** The first gated release run failed at changesets' version commit. `postinstall` had registered the repo's pre-commit hook on the runner; the gitleaks binary is not installed there, so the hook fell through to its Docker fallback, which passed `--source` to `gitleaks git` — a flag that only exists on the deprecated subcommands. The commit failed and the job died before anything was versioned or published.

- `postinstall` now skips hook registration when `CI` is set. CI runs its own pinned, checksum-verified gitleaks job, and the release commit is produced by changesets from an already-scanned tree, so the dev-machine hook adds nothing there.
- The Docker fallback (for Linux machines without the binary) now passes the repo as the positional argument `gitleaks git` expects, pins the image to the same v8.30.1 CI uses instead of `latest`, and marks the bind-mounted repo as a git `safe.directory` since the container's git runs as root over a host-owned mount. Verified against the `gitleaks git` usage output from the failed run; not executed end-to-end (no Docker daemon on the dev machine).

**Dependabot E2E.** Dependabot-triggered runs receive repository variables but not Actions secrets, so the auth-sample server fails every request with "Openfort secret key is not set" and both Playwright jobs burn their timeouts before failing (see #338). Both jobs now skip for `dependabot[bot]`; the `merge_group` trigger still runs the suite with real secrets before anything lands on main.

### Checklist

- [x] shellcheck and actionlint/zizmor pass on the touched files
- [x] `CI=true` guard verified to skip hook registration; unset `CI` verified to run it
- [ ] After merge: approve the `npm` environment on the new Release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)