### PR TITLE
Set up Frog and fix audit verification

### DIFF
--- a/.agents/friction-log/20260810200535-attw-fails-after/friction.md
+++ b/.agents/friction-log/20260810200535-attw-fails-after/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'attw fails after successful npm pack'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+`pnpm test:build` completes after `publint` and `npm pack` succeed.
+
+## Current Behavior
+
+`publint` passes and a direct `npm pack --dry-run` succeeds, but `attw --pack ./sdk` exits 3 with only `Command failed: npm pack`.
+
+## Possible Solution
+
+Expose the nested npm stderr or update the package-validation tooling once the incompatibility is identified.
+
+## Minimal Reproducible Example
+
+Run `pnpm build`, then `pnpm test:build` with Node 24 and npm 11. Running `cd sdk && npm pack --dry-run` succeeds in the same worktree.
+
+## Context
+
+Observed while running the required full verification after updating an audit override. It reproduces in an unrelated existing worktree, so it is not caused by the override.

--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -1,0 +1,38 @@
+# Friction log
+
+Friction hit while working in this repository, one directory per item:
+
+```
+<id>/
+  friction.md   the write-up
+  artifacts/    optional, whatever reproduces it
+```
+
+Reporting an entry gives it an owner. The write-up then carries an `issue:` link and mirrors what happens
+to it. The whole directory is deleted once the friction is resolved. Every entry left here is still
+outstanding, including friction in dependencies.
+
+Do not maintain an index here. This directory is the index.
+
+## Logging Friction
+
+```sh
+pnpx frog list    # what is already known
+pnpx frog log     # add one
+```
+
+`pnpx frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
+the directory reads oldest-first.
+
+Put anything that reproduces the friction in that entry's `artifacts/` and reference it from the
+write-up. The next reader runs the reproduction instead of rebuilding it.
+
+## For Agents
+
+Add these rules near the top of `AGENTS.md`, under the appropriate section. Create the file if missing; otherwise amend it in place, preserve all existing content, and never replace the file.
+
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
+- Do not add global, system, or internal friction.
+- Run `pnpx frog list` first to see what is already known.
+
+Managed by [Frog](https://github.com/wevm/frog).

--- a/.agents/friction-log/config.json
+++ b/.agents/friction-log/config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/frog/schema.json",
+  "inbound": {
+    "enabled": true
+  }
+}

--- a/.github/ISSUE_TEMPLATE/friction.yml
+++ b/.github/ISSUE_TEMPLATE/friction.yml
@@ -1,0 +1,34 @@
+name: Friction
+description: Something about this project cost you time.
+labels: [friction]
+body:
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Describe what should happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: Describe what happens instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Possible Solution
+      description: Optional. Suggest a fix or a reason for the friction.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Minimal Reproducible Example
+      description: Add a minimal reproducible example under `artifacts/`, or an unambiguous set of steps to reproduce this. Include code where relevant.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Context
+      description: Describe how this affected you, and what you were trying to accomplish.
+    validations:
+      required: false

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -1,0 +1,39 @@
+name: Friction Log
+on:
+  push:
+  issues:
+    types: [closed, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: friction-log
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  friction-log:
+    name: Friction Log
+    if: >-
+      (github.event_name != 'push' || github.ref_name == github.event.repository.default_branch) &&
+      (github.event_name != 'issues' || github.event.issue.user.login == 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Report and reconcile frictions
+        uses: wevm/frog/action@a9f4314e3317975c5a8a6f0fc71332d7110f72b6 # v1
+        with:
+          issue-author: github-actions[bot]
+          version: 1.0.15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Applies to humans and AI agents alike. `CLAUDE.md` points here.
 
+## Friction Logging
+
+- Run `pnpx frog list` first to see what friction is already known.
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
+- Do not add global, system, or internal friction.
+
 ## Layout
 
 - `sdk/` — `@openfort/openfort-js`, the only published package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   fast-xml-builder: '>=1.1.7'
   uuid: '>=11.1.1'
   postcss: '>=8.5.18'
+  nanoid@<3.3.17: '>=3.3.17 <4'
   sharp@<0.35.0: '>=0.35.0'
   websocket-driver@<0.7.5: '>=0.7.5'
   smol-toml@<1.6.1: '>=1.6.1'
@@ -5690,8 +5691,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -14284,7 +14285,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -14790,7 +14791,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ overrides:
   "fast-xml-builder": ">=1.1.7"
   "uuid": ">=11.1.1"
   "postcss": ">=8.5.18"
+  "nanoid@<3.3.17": ">=3.3.17 <4"
   "sharp@<0.35.0": ">=0.35.0"
   "websocket-driver@<0.7.5": ">=0.7.5"
   "smol-toml@<1.6.1": ">=1.6.1"


### PR DESCRIPTION
## Summary

- initialize the repository-local Frog friction log
- teach agents to inspect and record project friction
- add the pinned Action-only reconciliation workflow and issue form
- override vulnerable `nanoid <3.3.17`, resolving the audit failure at `3.3.18`
- record the pre-existing `attw --pack` local verification failure for follow-up

## Validation

- `pnpx frog list`
- `pnpm audit` (passes; remaining advisories are explicitly ignored by repository policy)
- `pnpm check:repo`
- `pnpm biome check`
- `pnpm build`
- `pnpm check:types`
- `pnpm test:types`
- `pnpm test:coverage` (31 files, 378 tests)
- `npm pack --dry-run`
- gitleaks pre-commit scans

`pnpm verify` reaches `pnpm test:build`, where the pre-existing `attw --pack ./sdk` command exits 3 despite direct `npm pack --dry-run` succeeding. The same failure reproduces in an unrelated existing worktree and is captured in the Frog log.

No changeset is needed because this does not change the published SDK package.