### PR TITLE
fix: remove KL1 testnet default RPC

### DIFF
--- a/.changeset/remove-kl1-chain.md
+++ b/.changeset/remove-kl1-chain.md
@@ -1,0 +1,5 @@
+---
+"@openfort/openfort-js": patch
+---
+
+Remove KL1 testnet (chain 3008) from the default chain RPC list

--- a/sdk/src/utils/chains/index.ts
+++ b/sdk/src/utils/chains/index.ts
@@ -13,7 +13,6 @@ export const defaultChainRpcs: { [key: number]: string } = {
   97: 'https://bsc-testnet.publicnode.com',
   137: 'https://polygon-rpc.com',
   1946: 'https://rpc.minato.soneium.org',
-  3008: 'https://kl1-testnet.kiooverse.xyz/rpc',
   4337: 'https://build.onbeam.com/rpc',
   8453: 'https://mainnet.base.org',
   10143: 'https://testnet-rpc.monad.xyz',


### PR DESCRIPTION
Removes the KL1 testnet (chain `3008`) fallback RPC from `defaultChainRpcs`, matching the removal of the chain from the API.

- drops `3008: https://kl1-testnet.kiooverse.xyz/rpc` from `sdk/src/utils/chains/index.ts`
- adds a patch changeset for `@openfort/openfort-js`

Companion API PR removes the chain definition, enum entry, explorer/apiKey/apiMap entries, paymaster alert threshold, and CoinGecko metadata.

Prompted by: Jaume Alavedra